### PR TITLE
Add vagrant environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 state/
 mbox/__pycache__
+openshift.local.clusterup/
+.vagrant/

--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ Option | Description
 `state_dir` | The location (relative or absolute) where the mbox state should be stored.
 `ca.built_in` | Whether to use the built-in certificate authority. If disabled, you are expected to create certificates manually. Valid options: `yes`, `no`.
 `ca.directory` | Used with `ca.built_in` set to `no`, to find where the certificates should be searched for.
-`database.built_in` | Which Postgres template to use from Openshift. Valid options: `persistent`, `transient` (warning: `transient` means all database contents will be gone on every pod restart - this is not recommended except for testing)
+`database.built_in` | Which Postgres template to use from Openshift. Valid options: `persistent`, `ephemeral` (warning: `ephemeral` means all database contents will be gone on every pod restart - this is not recommended except for testing)
 `store.mnt_koji_volname` | If specified, `mnt_koji` (persistent storage for koji) will request this volume name. If left blank, Openshift will assign a random valid PersistentVolume.
+`store.persistent_storage` | Whether to use persistent volume for koji. Possible values: `yes`, `no`. Use `no` only for testing or debugging purposes.
 `koji_hub.public_hostname` | The hostname to be used for the Koji hub. Needs to be pointed at the Openshift router nodes.
 `koji_hub.admin_username` | The username used for the Koji admin user.
 `kojira.username` | The username used for Kojira (General maintenance tasks in Koji).
 `builder.built_in` | Whether to deploy a builder into Openshift. Possible values: `yes`, `no`.
-`identity.built_in` | Whether to deploy an OpenID Connect identity provider into the Openshift project. Valud options: `yes`. (Using an external identity provider is an outstanding task, contributions welcome).
+`identity.built_in` | Whether to deploy an OpenID Connect identity provider into the Openshift project. Valid options: `yes`. (Using an external identity provider is an outstanding task, contributions welcome).
 `identity.public_hostname` | The hostname used for the built-in identity provider. Needs to be pointed at the Openshift router nodes.
 `identity.etc_ipsilon_volname` | The Openshift Persistent Volume to use for the identity provider temporary storage. Can be left blank for auto-assigned Persistent Volume.
 `mbs.public_hostname` | The hostname used for the Module Build Service deployment. Needs to be pointed at the Openshift router nodes.
@@ -41,3 +42,10 @@ This should result in a fully set up Koji and MBS setup, with one builder runnin
 ### Connecting
 The Koji instance should be available on the hostname configured as `koji_hub.public_hostname`.
 You can use the client certificate named after `koji_hub.admin_username` to connect with the CLI, or run `./main.py configfile.py koji` and then the rest of the standard koji CLI options, and the koji CLI will be run preconfigured.
+
+### Development environment
+This project uses vagrant as development environment. This will prepare the OpenShift instance with mbox project in it. To setup the development simply run `vagrant up` in root folder.
+
+To recreate the environment run `vagrant destroy && vagrant up`. `vagrant provision` will not work because of the various OpenShift commands ran by the ansible provisioning script.
+
+Follow MOTD for more information.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,69 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+require 'etc'
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+ config.vm.box = "fedora/30-cloud-base"
+
+# Forward traffic on the host to the development server on the guest
+# config.vm.network "forwarded_port", guest: 5000, host: 5000
+ # RabbitMQ
+ config.vm.network "forwarded_port", guest: 15672, host: 15672
+
+ # OpenShift
+ config.vm.network "forwarded_port", guest: 8443, host: 8443
+
+ if Vagrant.has_plugin?("vagrant-hostmanager")
+     config.hostmanager.enabled = true
+     config.hostmanager.manage_host = true
+ end
+
+ # Vagrant can share the source directory using rsync, NFS, or SSHFS (with the vagrant-sshfs
+ # plugin). By default it rsyncs the current working directory to /vagrant.
+ #
+ # If you would prefer to use NFS to share the directory uncomment this and configure NFS
+ # config.vm.synced_folder ".", "/vagrant", type: "nfs", nfs_version: 4, nfs_udp: false
+ config.vm.synced_folder ".", "/vagrant", disabled: true
+ config.vm.synced_folder ".", "/home/vagrant/devel", type: "sshfs"
+
+ # To cache update packages (which is helpful if frequently doing `vagrant destroy && vagrant up`)
+ # you can create a local directory and share it to the guest's DNF cache. The directory needs to
+ # exist, so create it before you uncomment the line below.
+ #
+ # config.vm.synced_folder ".dnf-cache", "/var/cache/dnf", type: "sshfs", sshfs_opts_append: "-o nonempty"
+
+ # Comment this line if you would like to disable the automatic update during provisioning
+ config.vm.provision "shell", inline: "sudo dnf upgrade -y"
+
+ # bootstrap and run with ansible
+ config.vm.provision "ansible" do |ansible|
+     ansible.playbook = "ansible/vagrant-playbook.yml"
+     ansible.raw_arguments = ["-e", "ansible_python_interpreter=/usr/bin/python3"]
+ end
+
+
+ # Create the "mbbox" box
+ config.vm.define "mbbox" do |mbbox|
+    mbbox.vm.host_name = "mbbox.example.com"
+
+    mbbox.vm.provider :libvirt do |domain|
+        # Season to taste
+        domain.cpus = Etc.nprocessors
+        domain.cpu_mode = "host-passthrough"
+        domain.graphics_type = "spice"
+        domain.memory = 4096
+        domain.video_type = "qxl"
+
+        # Uncomment the following line if you would like to enable libvirt's unsafe cache
+        # mode. It is called unsafe for a reason, as it causes the virtual host to ignore all
+        # fsync() calls from the guest. Only do this if you are comfortable with the possibility of
+        # your development guest becoming corrupted (in which case you should only need to do a
+        # vagrant destroy and vagrant up to get a new one).
+        #
+        # domain.volume_cache = "unsafe"
+    end
+ end
+end

--- a/ansible/roles/mbbox-dev/defaults/main.yml
+++ b/ansible/roles/mbbox-dev/defaults/main.yml
@@ -1,0 +1,2 @@
+import_production_database: true
+rabbitmq_cluster_file_limit: 500000

--- a/ansible/roles/mbbox-dev/files/.bashrc
+++ b/ansible/roles/mbbox-dev/files/.bashrc
@@ -1,0 +1,21 @@
+# .bashrc
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+	. /etc/bashrc
+fi
+
+# User specific environment
+if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]
+then
+    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
+fi
+
+export PATH
+
+# Uncomment the following line if you don't like systemctl's auto-paging feature:
+# export SYSTEMD_PAGER=
+
+# User specific aliases and functions
+
+alias oc='sudo oc'

--- a/ansible/roles/mbbox-dev/files/mbbox-dev.yml
+++ b/ansible/roles/mbbox-dev/files/mbbox-dev.yml
@@ -6,10 +6,10 @@ ca:
   built_in: yes
   directory: na
 database:
-  built_in: persistent
+  built_in: ephemeral
 storage:
   mnt_koji_volname: ""
-  persistent_storage: yes
+  persistent_storage: no
 koji_hub:
   public_hostname: koji.mbox.test
   admin_username: admin

--- a/ansible/roles/mbbox-dev/files/motd
+++ b/ansible/roles/mbbox-dev/files/motd
@@ -1,0 +1,23 @@
+
+Welcome to the mbbox development environment!
+
+Here are some tips:
+
+* The code is located at ~/devel/
+
+* Predefined configuration file is located at ~/mbbox-dev.yml
+
+* Then run mbbox script:
+  $ cd devel
+  # If you run the script before don't forget to remove current state
+  $ rm -rf state
+  $ sudo ./main.py ~/mbbox-dev.yml
+
+* To recreate openshift project:
+  $ oc delete project mbox
+  $ oc new-project mbox
+  $ oc tag --scheduled=true registry.centos.org/postgresql/postgresql postgresql:latest
+  $ oc adm router --ports='8443'
+
+Happy hacking!
+

--- a/ansible/roles/mbbox-dev/files/postgresql-ephemeral-template.json
+++ b/ansible/roles/mbbox-dev/files/postgresql-ephemeral-template.json
@@ -1,0 +1,253 @@
+{
+    "apiVersion": "v1",
+    "kind": "Template",
+    "labels": {
+        "template": "postgresql-ephemeral-template"
+    },
+    "message": "The following service(s) have been created in your project: ${DATABASE_SERVICE_NAME}.\n\n       Username: ${POSTGRESQL_USER}\n       Password: ${POSTGRESQL_PASSWORD}\n  Database Name: ${POSTGRESQL_DATABASE}\n Connection URL: postgresql://${DATABASE_SERVICE_NAME}:5432/\n\nFor more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.",
+    "metadata": {
+        "annotations": {
+            "description": "PostgreSQL database service, without persistent storage. For more information about using this template, including OpenShift considerations, see https://github.com/sclorg/postgresql-container/.\n\nWARNING: Any data stored will be lost upon pod destruction. Only use this template for testing",
+            "iconClass": "icon-postgresql",
+            "openshift.io/display-name": "PostgreSQL (Ephemeral)",
+            "openshift.io/documentation-url": "https://docs.openshift.org/latest/using_images/db_images/postgresql.html",
+            "openshift.io/long-description": "This template provides a standalone PostgreSQL server with a database created.  The database is not stored on persistent storage, so any restart of the service will result in all data being lost.  The database name, username, and password are chosen via parameters when provisioning this service.",
+            "openshift.io/provider-display-name": "Red Hat, Inc.",
+            "openshift.io/support-url": "https://access.redhat.com",
+            "tags": "database,postgresql"
+        },
+        "name": "postgresql-ephemeral"
+    },
+    "objects": [
+        {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "annotations": {
+                    "template.openshift.io/expose-database_name": "{.data['database-name']}",
+                    "template.openshift.io/expose-password": "{.data['database-password']}",
+                    "template.openshift.io/expose-username": "{.data['database-user']}"
+                },
+                "name": "${DATABASE_SERVICE_NAME}"
+            },
+            "stringData": {
+                "database-name": "${POSTGRESQL_DATABASE}",
+                "database-password": "${POSTGRESQL_PASSWORD}",
+                "database-user": "${POSTGRESQL_USER}"
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "metadata": {
+                "annotations": {
+                    "template.openshift.io/expose-uri": "postgres://{.spec.clusterIP}:{.spec.ports[?(.name==\"postgresql\")].port}"
+                },
+                "name": "${DATABASE_SERVICE_NAME}"
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "postgresql",
+                        "nodePort": 0,
+                        "port": 5432,
+                        "protocol": "TCP",
+                        "targetPort": 5432
+                    }
+                ],
+                "selector": {
+                    "name": "${DATABASE_SERVICE_NAME}"
+                },
+                "sessionAffinity": "None",
+                "type": "ClusterIP"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "apiVersion": "v1",
+            "kind": "DeploymentConfig",
+            "metadata": {
+                "annotations": {
+                    "template.alpha.openshift.io/wait-for-ready": "true"
+                },
+                "name": "${DATABASE_SERVICE_NAME}"
+            },
+            "spec": {
+                "replicas": 1,
+                "selector": {
+                    "name": "${DATABASE_SERVICE_NAME}"
+                },
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "name": "${DATABASE_SERVICE_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "capabilities": {},
+                                "env": [
+                                    {
+                                        "name": "POSTGRESQL_USER",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "database-user",
+                                                "name": "${DATABASE_SERVICE_NAME}"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_PASSWORD",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "database-password",
+                                                "name": "${DATABASE_SERVICE_NAME}"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_DATABASE",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "key": "database-name",
+                                                "name": "${DATABASE_SERVICE_NAME}"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "image": " ",
+                                "imagePullPolicy": "IfNotPresent",
+                                "livenessProbe": {
+                                    "tcpSocket": {
+                                        "port": 5432
+                                    },
+                                    "initialDelaySeconds": 120,
+                                    "timeoutSeconds": 10
+                                },
+                                "name": "postgresql",
+                                "ports": [
+                                    {
+                                        "containerPort": 5432,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "tcpSocket": {
+                                        "port": 5432
+                                    },
+                                    "initialDelaySeconds": 5,
+                                    "timeoutSeconds": 1
+                                },
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${MEMORY_LIMIT}"
+                                    }
+                                },
+                                "securityContext": {
+                                    "capabilities": {},
+                                    "privileged": false
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/lib/pgsql/data",
+                                        "name": "${DATABASE_SERVICE_NAME}-data"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "volumes": [
+                            {
+                                "emptyDir": {
+                                    "medium": ""
+                                },
+                                "name": "${DATABASE_SERVICE_NAME}-data"
+                            }
+                        ]
+                    }
+                },
+                "triggers": [
+                    {
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "postgresql"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "postgresql:${POSTGRESQL_VERSION}",
+                                "namespace": "mbox"
+                            },
+                            "lastTriggeredImage": ""
+                        },
+                        "type": "ImageChange"
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ]
+            },
+            "status": {}
+        }
+    ],
+    "parameters": [
+        {
+            "description": "Maximum amount of memory the container can use.",
+            "displayName": "Memory Limit",
+            "name": "MEMORY_LIMIT",
+            "required": true,
+            "value": "512Mi"
+        },
+        {
+            "description": "The OpenShift Namespace where the ImageStream resides.",
+            "displayName": "Namespace",
+            "name": "NAMESPACE",
+            "value": "openshift"
+        },
+        {
+            "description": "The name of the OpenShift Service exposed for the database.",
+            "displayName": "Database Service Name",
+            "name": "DATABASE_SERVICE_NAME",
+            "required": true,
+            "value": "postgresql"
+        },
+        {
+            "description": "Username for PostgreSQL user that will be used for accessing the database.",
+            "displayName": "PostgreSQL Connection Username",
+            "from": "user[A-Z0-9]{3}",
+            "generate": "expression",
+            "name": "POSTGRESQL_USER",
+            "required": true
+        },
+        {
+            "description": "Password for the PostgreSQL connection user.",
+            "displayName": "PostgreSQL Connection Password",
+            "from": "[a-zA-Z0-9]{16}",
+            "generate": "expression",
+            "name": "POSTGRESQL_PASSWORD",
+            "required": true
+        },
+        {
+            "description": "Name of the PostgreSQL database accessed.",
+            "displayName": "PostgreSQL Database Name",
+            "name": "POSTGRESQL_DATABASE",
+            "required": true,
+            "value": "sampledb"
+        },
+        {
+            "description": "Version of PostgreSQL image to be used (9.4, 9.5, 9.6 or latest).",
+            "displayName": "Version of PostgreSQL Image",
+            "name": "POSTGRESQL_VERSION",
+            "required": true,
+            "value":  "latest"
+        }
+    ]
+}

--- a/ansible/roles/mbbox-dev/handlers/main.yml
+++ b/ansible/roles/mbbox-dev/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: reload rabbitmq
+  systemd:
+    name: rabbitmq-server
+    state: restarted
+    daemon_reload: yes

--- a/ansible/roles/mbbox-dev/tasks/main.yml
+++ b/ansible/roles/mbbox-dev/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Install helpful development packages
+  dnf:
+    name: [
+           git,
+           vim-enhanced,
+           python3-black,
+           tmux,
+           htop
+          ]
+    state: present
+
+- name: Install mbbox system dependencies
+  dnf:
+    name: [
+           origin-clients,
+           docker
+          ]
+    state: present
+
+# Add various helpful configuration files
+- name: Install the message of the day
+  copy: src=motd dest=/etc/motd
+
+- name: Copy bashrc
+  copy: src=.bashrc dest=/home/vagrant/.bashrc
+
+- name: Copy test configuration
+  copy: src=mbbox-dev.yml dest=/home/vagrant/mbbox-dev.yml
+
+- import_tasks: rabbitmq.yml
+- import_tasks: openshift.yml

--- a/ansible/roles/mbbox-dev/tasks/openshift.yml
+++ b/ansible/roles/mbbox-dev/tasks/openshift.yml
@@ -1,0 +1,63 @@
+---
+- name: Install openshift dependencies
+  dnf:
+    name: [
+           origin-clients
+          ]
+    state: present
+
+# Setup openshift registry
+- name: Add insecure-registries entry
+  replace:
+    path: /etc/containers/registries.conf
+    after: 'registries.insecure'
+    before: 'registries.block'
+    regexp: '^(registries =).*$'
+    replace: '\1 ["172.30.0.0/16"]'
+
+- name: Restart registries
+  systemd:
+    state: restarted
+    name: registries
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1558425
+- name: Add cgroups to docker systemd service
+  replace:
+    path: /usr/lib/systemd/system/docker.service
+    regexp: '(native.cgroupdriver=)systemd'
+    replace: '\1cgroupfs'
+
+- name: Start docker
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: docker
+
+- name: Start cluster
+  command: oc cluster up --enable=[router, registry, web-console]
+
+- name: Add registry
+  command: oc cluster add registry
+
+- name: Create project
+  command: oc new-project mbox
+
+# Setup postgresql template
+- name: Copy template
+  copy: src=postgresql-ephemeral-template.json dest=/tmp/postgresql-ephemeral-template.json
+
+- name: Switch to admin user
+  command: oc login -u system:admin
+
+- name: Install PostgreSQL templates
+  command: oc create -f "/tmp/postgresql-ephemeral-template.json" -n openshift
+
+- name: Use centos registry for postgress imagestream
+  command: oc tag --scheduled=true registry.centos.org/postgresql/postgresql postgresql:latest
+
+# Setup openshift router
+- name: Grant router access to host network
+  command: oc adm policy add-scc-to-user hostnetwork -z router
+
+- name: Deploy router
+  command: oc adm router --ports='8443'

--- a/ansible/roles/mbbox-dev/tasks/rabbitmq.yml
+++ b/ansible/roles/mbbox-dev/tasks/rabbitmq.yml
@@ -1,0 +1,34 @@
+---
+- name: Install RabbitMQ packages
+  package:
+      name: "{{ item }}"
+      state: present
+  with_items:
+      - rabbitmq-server
+
+- name: Create RabbitMQ systemd override directory
+  file:
+    path: /etc/systemd/system/rabbitmq-server.service.d/
+    state: directory
+
+- name: Override file limit on rabbitmq
+  copy:
+    content: "[Service]\nLimitNOFILE={{rabbitmq_cluster_file_limit}}\n"
+    dest: /etc/systemd/system/rabbitmq-server.service.d/override.conf
+  notify:
+    - reload rabbitmq
+
+- name: Enables the rabbitmq management and SSL authentication plugins
+  rabbitmq_plugin:
+    names: rabbitmq_management,rabbitmq_auth_mechanism_ssl
+  notify:
+    - reload rabbitmq
+
+- name: Ensure that .erlang.cookie has correct owner
+  file:
+    path: /var/lib/rabbitmq/.erlang.cookie
+    owner: rabbitmq
+    group: rabbitmq
+
+- name: start rabbitmq
+  service: name=rabbitmq-server state=started enabled=yes

--- a/ansible/vagrant-playbook.yml
+++ b/ansible/vagrant-playbook.yml
@@ -1,0 +1,7 @@
+---
+- hosts: all
+  become: true
+  become_method: sudo
+  vars:
+  roles:
+    - mbbox-dev

--- a/components/identity/buildconfig.yml
+++ b/components/identity/buildconfig.yml
@@ -20,12 +20,12 @@ spec:
     dockerfile: |-
       # Apache on centos7 keeps throwing segfaults...
       #FROM centos:7
-      FROM fedora:latest
+      FROM fedora:31
       COPY cacert/cert /etc/pki/ca-trust/source/anchors/mbox_ca.pem
       RUN update-ca-trust
-      RUN yum install -y ipsilon ipsilon-openidc python2-psycopg2
+      RUN dnf install -y ipsilon ipsilon-openidc python2-psycopg2
       # Don't try to fix permissions
       # Should go to upstream
-      RUN printf "def fix_user_dirs(*args, **kwargs):\n    pass\n" >>/usr/lib/python2.7/site-packages/ipsilon/tools/files.py
+      RUN printf "def fix_user_dirs(*args, **kwargs):\n    pass\n" >>/usr/lib/python3.7/site-packages/ipsilon/tools/files.py
       EXPOSE 8443
       ENTRYPOINT bash /etc/ipsilon-cfg/start.sh

--- a/components/identity/configmap.yml
+++ b/components/identity/configmap.yml
@@ -69,7 +69,7 @@ data:
     confdir = /etc/ipsilon/ipsilon
 
     [arguments]
-    ignored_database_url = postgresql://{{ databse_username }}:{{ database_password }}@{{ database_hostname }}/{{ database_name }}
+    ignored_database_url = postgresql://{{ database_username }}:{{ database_password }}@{{ database_hostname }}/{{ database_name }}
     admin_user = admin
     gssapi = no
     ipa = no

--- a/components/koji_hub/buildconfig.yml
+++ b/components/koji_hub/buildconfig.yml
@@ -20,10 +20,10 @@ spec:
     dockerfile: |-
       # Apache on centos7 keeps throwing segfaults...
       #FROM centos:7
-      FROM fedora:latest
+      FROM fedora:31
       COPY cacert/cert /etc/pki/ca-trust/source/anchors/mbox_ca.pem
       RUN update-ca-trust
-      RUN yum install --setopt tsflags= -y koji koji-hub koji-web koji-hub-plugins httpd mod_ssl postgresql fedmsg
+      RUN dnf install --setopt tsflags= -y koji koji-hub koji-web koji-hub-plugins httpd mod_ssl postgresql fedmsg python3-mod_wsgi 
       RUN curl https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/roles/koji_hub/templates/fedmsg-koji-plugin.py -o /usr/lib/koji-hub-plugins/fedmsg-koji-plugin.py
       RUN rm -f /etc/kojiweb/web.conf
       RUN ln -s /etc/koji-hub/kojiweb.conf /etc/kojiweb/web.conf

--- a/components/koji_hub/configmap.yml
+++ b/components/koji_hub/configmap.yml
@@ -4,8 +4,8 @@ metadata:
   name: koji-hub-configmap
 data:
   start.sh: |-
-    mkdir /httpdir/run
-    ln -s /etc/httpd/modules /httpdir/modules
+    mkdir -p /httpdir/run/
+    ln -s /usr/lib64/httpd/modules /httpdir/modules
     truncate --size=0 /httpdir/accesslog /httpdir/errorlog
     tail -qf /httpdir/accesslog /httpdir/errorlog &
     ulimit -c 0
@@ -30,7 +30,7 @@ data:
     LoadModule alias_module modules/mod_alias.so
     LoadModule rewrite_module modules/mod_rewrite.so
     LoadModule version_module modules/mod_version.so
-    LoadModule wsgi_module modules/mod_wsgi.so
+    LoadModule wsgi_module modules/mod_wsgi_python3.so
     LoadModule authn_core_module modules/mod_authn_core.so
     LoadModule authz_core_module modules/mod_authz_core.so
     LoadModule unixd_module modules/mod_unixd.so

--- a/components/koji_hub/deploymentconfig.yml
+++ b/components/koji_hub/deploymentconfig.yml
@@ -82,8 +82,12 @@ spec:
       - name: httpdir-volume
         emptyDir: {}
       - name: mntkoji
+{% if persistent_storage %}
         persistentVolumeClaim:
          claimName: mntkoji
+{% else %}
+        emptyDir: {}
+{% endif %}
   triggers:
   - imageChangeParams:
       automatic: true


### PR DESCRIPTION
Vagrant environment sets up OpenShift environment for development.
The liveliness and readiness probe for koji is still not working.
This causes error to be thrown at the end of the mbbox script.

Koji still needs some work, but this environment should be enough to
start working with this script locally.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>