### PR TITLE
mbox operator project

### DIFF
--- a/ansible/roles/openshift-osdk/defaults/main.yml
+++ b/ansible/roles/openshift-osdk/defaults/main.yml
@@ -1,2 +1,3 @@
 minikube_version: 1.7.3-0
 operator_sdk_version: 0.12.0
+dev_username: vagrant

--- a/ansible/roles/openshift-osdk/files/motd
+++ b/ansible/roles/openshift-osdk/files/motd
@@ -7,26 +7,39 @@ Here are some tips:
 
 * Dev environment is set for the development of ansible based operator for OpenShift, for more info look at https://docs.openshift.com/container-platform/4.3/operators/operator_sdk/osdk-ansible.html
 
-* To test the operator in kubernetes cluster:
-  # Build the image and upload it to quay
-  # This needs to be done every time you made a change to container
-  $ operator_sdk build quay.io/username/mbbox-operator
-  $ docker push quay.io/username/mbbox-operator
+* To test the operator in the local kubernetes cluster
+# This command runs automated E2E (end to end) tests in the local kubernetes cluster
 
-  # Add the mbbox-operator to kubernetes cluster
-  # This needs to be done only once
-  $ oc create -f deploy/service_account.yaml
-  $ oc create -f deploy/role.yaml
-  $ oc create -f deploy/role_binding.yaml
-  $ oc create -f deploy/operator.yaml
+$ operator-sdk test local
+
+* To deploy and run the mbox operator in the local kubernetes cluster:
+  # Build the image and upload it to quay
+  # This needs to be done every time you made a change to the operator code
+  # You may also need to update the image name in mbox-operator/deploy/operator.yaml
+  $ operator-sdk build quay.io/username/mbbox-operator:tag
+  $ docker push quay.io/username/mbbox-operator:tag
+
+  # Create the mbbox-operator requirements to the local kubernetes cluster
+  # This needs to be done only once unless there was a change in any of those resources
+  $ oc apply -f mbox-operator/deploy/crds/apps.fedoraproject.org_mboxes_crd.yaml
+  $ oc apply -f mbox-operator/deploy/service_account.yaml
+  $ oc apply -f mbox-operator/deploy/role.yaml
+  $ oc apply -f mbox-operator/deploy/role_binding.yaml
+  
+  # Deploy the operator
+  $ oc create -f mbox-operator/deploy/operator.yaml
 
   # Verify the operator is up and running
-  $ oc get deployment
+  # There should be a pod with two containers (ansible and operator)
+  $ oc get deployment -w
+
+  # Create a mbox custom resource
+  $ oc create -f mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml
 
 * To debug kubernetes deployment here are a few tips
   * oc get all - help you see what is currently in kubernetes cluster
   * oc describe pod/<name> - will give you some overview
-  * oc logs pod/<name> - will show you logs of the pod
+  * oc logs pod/<name> <container> - will show you logs of the pod
 
 Happy hacking!
 

--- a/ansible/roles/openshift-osdk/tasks/operator-sdk.yml
+++ b/ansible/roles/openshift-osdk/tasks/operator-sdk.yml
@@ -1,17 +1,38 @@
 ---
-- name: Install Operator SDK dependencies
+- name: Install Operator SDK system dependencies
   dnf:
     name: [
             golang,
-            docker,
-            ansible,
-            python3-ansible-runner
+            docker
           ]
     state: present
 
-- name: Install OpenShift python package
+- name: Install Operator SDK python dependencies
   pip:
-    name: openshift
+    name: [
+      'ansible',
+      'flake8',
+      'ansible-lint',
+      'molecule',
+      'molecule[docker]',
+      'docker',
+      'kubernetes',
+      'jmespath',
+      'openshift'
+    ]
+
+- name: Create docker group
+  group:
+    name: docker
+    state: present
+  become: yes
+
+- name: Ensure user is added to docker group
+  user:
+    name: "{{ dev_username }}"
+    groups: ['docker']
+    append: yes
+  become: yes
 
 - name: Start docker
   systemd:
@@ -67,3 +88,6 @@
     dest: /usr/local/bin/operator-sdk
     mode: '0755'
     remote_src: yes
+
+
+#docker config

--- a/mbox-operator/.yamllint
+++ b/mbox-operator/.yamllint
@@ -1,0 +1,13 @@
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  document-start: disable
+  line-length: disable
+  truthy:
+    allowed-values: ['true', 'false']

--- a/mbox-operator/README.md
+++ b/mbox-operator/README.md
@@ -1,0 +1,42 @@
+# MBOX Operator
+
+An ansible kubernetes operator for MBOX (Module Building in a Box).
+
+Upstream ansible kubernetes operator docs: https://github.com/operator-framework/operator-sdk/tree/master/doc/ansible
+
+## Usage
+
+All commands work with `oc` as well.
+
+Operator deployment and CRD creation (crds need to be create before deploying the operator):
+
+```
+kubectl apply -f deploy/crds/deploy/crds/apps.fedoraproject.org_mboxes_crd.yaml
+kubectl apply -f deploy/
+```
+
+Checking if the operator is successfully running:
+
+```
+$ kubectl get pods -w
+NAME                              READY   STATUS    RESTARTS   AGE
+mbox-operator-6867d56dd4-q2ddq   2/2     Running   0          11m
+```
+
+Creating a mbox resource:
+
+```
+kubectl apply -f deploy/crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml
+```
+
+## Development
+
+Upstream user and development guide: https://github.com/operator-framework/operator-sdk/blob/master/doc/ansible/user-guide.md
+
+## Testing
+
+The operator sdk provides a `test`  subcommand which runs E2E tests against a cluster using the molecule cli.
+
+It will run all tests added in the molecule folder, new tests have to added in molecule (`default/asserts.yml`) if changes were made in the operator itself.
+
+More information on E2E testing can be found in the upstream documentation: https://github.com/operator-framework/operator-sdk/blob/master/doc/ansible/dev/testing_guide.md

--- a/mbox-operator/build/Dockerfile
+++ b/mbox-operator/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM quay.io/operator-framework/ansible-operator:v0.15.2
+
+COPY watches.yaml ${HOME}/watches.yaml
+
+COPY roles/ ${HOME}/roles/

--- a/mbox-operator/build/test-framework/Dockerfile
+++ b/mbox-operator/build/test-framework/Dockerfile
@@ -1,0 +1,16 @@
+ARG BASEIMAGE
+FROM ${BASEIMAGE}
+USER 0
+
+# Ensure fresh metadata rather than cached metadata in the base by running
+# yum clean all && rm -rf /var/yum/cache/* first
+RUN yum clean all && rm -rf /var/cache/yum/* \
+ && yum -y update \ 
+ && yum install -y python36-devel gcc libffi-devel python3-pip
+RUN pip3 install --user molecule==2.22
+ARG NAMESPACEDMAN
+ADD $NAMESPACEDMAN /namespaced.yaml
+ADD build/test-framework/ansible-test.sh /ansible-test.sh
+RUN chmod +x /ansible-test.sh
+USER 1001
+ADD . /opt/ansible/project

--- a/mbox-operator/build/test-framework/ansible-test.sh
+++ b/mbox-operator/build/test-framework/ansible-test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+export WATCH_NAMESPACE=${TEST_NAMESPACE}
+(/usr/local/bin/entrypoint)&
+trap "kill $!" SIGINT SIGTERM EXIT
+
+cd ${HOME}/project
+exec molecule test -s test-cluster

--- a/mbox-operator/deploy/crds/apps.fedoraproject.org_mboxes_crd.yaml
+++ b/mbox-operator/deploy/crds/apps.fedoraproject.org_mboxes_crd.yaml
@@ -1,0 +1,22 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mboxes.apps.fedoraproject.org
+spec:
+  group: apps.fedoraproject.org
+  names:
+    kind: Mbox
+    listKind: MboxList
+    plural: mboxes
+    singular: mbox
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      type: object
+      x-kubernetes-preserve-unknown-fields: true
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml
+++ b/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps.fedoraproject.org/v1alpha1
+kind: Mbox
+metadata:
+  name: example-mbox
+spec:
+  # Add fields here
+  size: 3

--- a/mbox-operator/deploy/operator.yaml
+++ b/mbox-operator/deploy/operator.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mbox-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mbox-operator
+  template:
+    metadata:
+      labels:
+        name: mbox-operator
+    spec:
+      serviceAccountName: mbox-operator
+      containers:
+        - name: ansible
+          command:
+            - /usr/local/bin/ao-logs
+            - /tmp/ansible-operator/runner
+            - stdout
+          # Replace this with the built image name
+          image: quay.io/fedora/mbox-operator:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /tmp/ansible-operator/runner
+              name: runner
+              readOnly: true
+        - name: operator
+          # Replace this with the built image name
+          image: quay.io/fedora/mbox-operator:latest
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /tmp/ansible-operator/runner
+              name: runner
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "mbox-operator"
+            - name: ANSIBLE_GATHERING
+              value: explicit
+      volumes:
+        - name: runner
+          emptyDir: {}

--- a/mbox-operator/deploy/role.yaml
+++ b/mbox-operator/deploy/role.yaml
@@ -1,0 +1,80 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: mbox-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+    verbs:
+      - get
+      - create
+  - apiGroups:
+      - apps
+    resourceNames:
+      - mbox-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+      - deployments
+    verbs:
+      - get
+  - apiGroups:
+      - apps.fedoraproject.org
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch

--- a/mbox-operator/deploy/role_binding.yaml
+++ b/mbox-operator/deploy/role_binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: mbox-operator
+subjects:
+  - kind: ServiceAccount
+    name: mbox-operator
+roleRef:
+  kind: Role
+  name: mbox-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/mbox-operator/deploy/service_account.yaml
+++ b/mbox-operator/deploy/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mbox-operator

--- a/mbox-operator/molecule/default/asserts.yml
+++ b/mbox-operator/molecule/default/asserts.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Verify
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+  tasks:
+    - name: Get all pods in {{ namespace }}
+      k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: '{{ namespace }}'
+      register: pods
+
+    - name: Output pods
+      debug: var=pods

--- a/mbox-operator/molecule/default/converge.yml
+++ b/mbox-operator/molecule/default/converge.yml
@@ -1,0 +1,10 @@
+---
+- name: Converge
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+  roles:
+    - mbox
+
+- import_playbook: '{{ playbook_dir }}/asserts.yml'

--- a/mbox-operator/molecule/default/molecule.yml
+++ b/mbox-operator/molecule/default/molecule.yml
@@ -1,0 +1,42 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+  enabled: false
+platforms:
+  - name: kind-default
+    groups:
+      - k8s
+    image: bsycorp/kind:latest-1.15
+    privileged: true
+    override_command: false
+    exposed_ports:
+      - 8443/tcp
+      - 10080/tcp
+    published_ports:
+      - 0.0.0.0:${TEST_CLUSTER_PORT:-9443}:8443/tcp
+    pre_build_image: true
+provisioner:
+  name: ansible
+  log: true
+  lint:
+    name: ansible-lint
+    enabled: false
+  inventory:
+    group_vars:
+      all:
+        namespace: ${TEST_NAMESPACE:-osdk-test}
+  env:
+    K8S_AUTH_KUBECONFIG: /tmp/molecule/kind-default/kubeconfig
+    KUBECONFIG: /tmp/molecule/kind-default/kubeconfig
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
+    KIND_PORT: '${TEST_CLUSTER_PORT:-9443}'
+scenario:
+  name: default
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/mbox-operator/molecule/default/prepare.yml
+++ b/mbox-operator/molecule/default/prepare.yml
@@ -1,0 +1,35 @@
+---
+- name: Prepare
+  hosts: k8s
+  gather_facts: false
+  vars:
+    kubeconfig: "{{ lookup('env', 'KUBECONFIG') }}"
+  tasks:
+    - name: delete the kubeconfig if present
+      file:
+        path: '{{ kubeconfig }}'
+        state: absent
+      delegate_to: localhost
+
+    - name: Fetch the kubeconfig
+      fetch:
+        dest: '{{ kubeconfig }}'
+        flat: true
+        src: /root/.kube/config
+
+    - name: Change the kubeconfig port to the proper value
+      replace:
+        regexp: '8443'
+        replace: "{{ lookup('env', 'KIND_PORT') }}"
+        path: '{{ kubeconfig }}'
+      delegate_to: localhost
+
+    - name: Wait for the Kubernetes API to become available (this could take a minute)
+      uri:
+        url: "http://localhost:10080/kubernetes-ready"
+        status_code: 200
+        validate_certs: false
+      register: result
+      until: (result.status|default(-1)) == 200
+      retries: 60
+      delay: 5

--- a/mbox-operator/molecule/test-cluster/converge.yml
+++ b/mbox-operator/molecule/test-cluster/converge.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Converge
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+    image_name: apps.fedoraproject.org/mbox-operator:testing
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml'])) | from_yaml }}"
+  tasks:
+    - name: Create the apps.fedoraproject.org/v1alpha1.Mbox
+      k8s:
+        namespace: '{{ namespace }}'
+        definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml'])) }}"
+
+    - name: Get the newly created Custom Resource
+      debug:
+        msg: "{{ lookup('k8s', group='apps.fedoraproject.org', api_version='v1alpha1', kind='Mbox', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
+
+    - name: Wait 2m for reconciliation to run
+      k8s_info:
+        api_version: 'v1alpha1'
+        kind: 'Mbox'
+        namespace: '{{ namespace }}'
+        name: '{{ custom_resource.metadata.name }}'
+      register: reconcile_cr
+      until:
+        - "'Successful' in (reconcile_cr | json_query('resources[].status.conditions[].reason'))"
+      delay: 12
+      retries: 10
+
+- import_playbook: '{{ playbook_dir }}/../default/asserts.yml'

--- a/mbox-operator/molecule/test-cluster/molecule.yml
+++ b/mbox-operator/molecule/test-cluster/molecule.yml
@@ -1,0 +1,43 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: delegated
+  options:
+    managed: true
+    ansible_connection_options: {}
+lint:
+  name: yamllint
+  enabled: false
+platforms:
+  - name: test-cluster
+    groups:
+      - k8s
+provisioner:
+  name: ansible
+  inventory:
+    group_vars:
+      all:
+        namespace: ${TEST_NAMESPACE:-osdk-test}
+  lint:
+    name: ansible-lint
+    enabled: false
+  env:
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
+scenario:
+  name: test-cluster
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - side_effect
+    - verify
+    - destroy
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/mbox-operator/molecule/test-local/converge.yml
+++ b/mbox-operator/molecule/test-local/converge.yml
@@ -1,0 +1,117 @@
+---
+
+- name: Build Operator in Kubernetes docker container
+  hosts: k8s
+  vars:
+    image_name: apps.fedoraproject.org/mbox-operator:testing
+    dockerfile_path: /build/build/Dockerfile
+  tasks:
+    # using command so we don't need to install any dependencies
+    - name: Get existing image hash
+      command: docker images -q {{ image_name }}
+      register: prev_hash
+      changed_when: false
+
+    - name: Build Operator Image
+      command: docker build -f {{ dockerfile_path }} -t {{ image_name }} /build
+      register: build_cmd
+      changed_when: not prev_hash.stdout or (prev_hash.stdout and prev_hash.stdout not in ''.join(build_cmd.stdout_lines[-2:]))
+
+- name: Converge
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+    pull_policy: Never
+    REPLACE_IMAGE: apps.fedoraproject.org/mbox-operator:testing
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml'])) | from_yaml }}"
+  tasks:
+    - block:
+        - name: Delete the Operator Deployment
+          k8s:
+            state: absent
+            namespace: '{{ namespace }}'
+            definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
+          register: delete_deployment
+          when: hostvars[groups.k8s.0].build_cmd.changed
+
+        - name: Wait 30s for Operator Deployment to terminate
+          k8s_info:
+            api_version: '{{ definition.apiVersion }}'
+            kind: '{{ definition.kind }}'
+            namespace: '{{ namespace }}'
+            name: '{{ definition.metadata.name }}'
+          vars:
+            definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+          register: deployment
+          until: not deployment.resources
+          delay: 3
+          retries: 10
+          when: delete_deployment.changed
+
+        - name: Create the Operator Deployment
+          k8s:
+            namespace: '{{ namespace }}'
+            definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) }}"
+
+        - name: Create the apps.fedoraproject.org/v1alpha1.Mbox
+          k8s:
+            state: present
+            namespace: '{{ namespace }}'
+            definition: '{{ custom_resource }}'
+
+        - name: Wait 2m for reconciliation to run
+          k8s_info:
+            api_version: '{{ custom_resource.apiVersion }}'
+            kind: '{{ custom_resource.kind }}'
+            namespace: '{{ namespace }}'
+            name: '{{ custom_resource.metadata.name }}'
+          register: cr
+          until:
+            - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
+          delay: 12
+          retries: 10
+      rescue:
+        - name: debug cr
+          ignore_errors: true
+          failed_when: false
+          debug:
+            var: debug_cr
+          vars:
+            debug_cr: '{{ lookup("k8s",
+              kind=custom_resource.kind,
+              api_version=custom_resource.apiVersion,
+              namespace=namespace,
+              resource_name=custom_resource.metadata.name
+            )}}'
+
+        - name: debug memcached lookup
+          ignore_errors: true
+          failed_when: false
+          debug:
+            var: deploy
+          vars:
+            deploy: '{{ lookup("k8s",
+              kind="Deployment",
+              api_version="apps/v1",
+              namespace=namespace,
+              label_selector="app=memcached"
+            )}}'
+
+        - name: get operator logs
+          ignore_errors: true
+          failed_when: false
+          command: kubectl logs deployment/{{ definition.metadata.name }} -n {{ namespace }}
+          environment:
+            KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+          vars:
+            definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+          register: log
+
+        - debug: var=log.stdout_lines
+
+        - fail:
+            msg: "Failed on action: converge"
+
+- import_playbook: '{{ playbook_dir }}/../default/asserts.yml'

--- a/mbox-operator/molecule/test-local/molecule.yml
+++ b/mbox-operator/molecule/test-local/molecule.yml
@@ -1,0 +1,53 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint: |
+  yamllint .
+platforms:
+  - name: kind-test-local
+    groups:
+      - k8s
+    image: bsycorp/kind:latest-1.15
+    privileged: true
+    override_command: false
+    exposed_ports:
+      - 8443/tcp
+      - 10080/tcp
+    published_ports:
+      - 0.0.0.0:${TEST_CLUSTER_PORT:-10443}:8443/tcp
+    pre_build_image: true
+    volumes:
+      - ${MOLECULE_PROJECT_DIRECTORY}:/build:Z
+provisioner:
+  name: ansible
+  log: true
+  lint: |
+    ansible-lint .
+  inventory:
+    group_vars:
+      all:
+        namespace: ${TEST_NAMESPACE:-osdk-test}
+  env:
+    K8S_AUTH_KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig
+    KUBECONFIG: /tmp/molecule/kind-test-local/kubeconfig
+    ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
+    KIND_PORT: '${TEST_CLUSTER_PORT:-10443}'
+scenario:
+  name: test-local
+  test_sequence:
+    - lint
+    - destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    - side_effect
+    - verify
+    - destroy
+verifier:
+  name: testinfra
+  lint: |
+    flake8

--- a/mbox-operator/molecule/test-local/prepare.yml
+++ b/mbox-operator/molecule/test-local/prepare.yml
@@ -1,0 +1,29 @@
+---
+- import_playbook: ../default/prepare.yml
+
+- name: Prepare operator resources
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+    crd_path: 'crds/apps.fedoraproject.org_mboxes_crd.yaml'
+  tasks:
+    - name: Create Custom Resource Definition
+      k8s:
+        definition: "{{ lookup('file', '/'.join([deploy_dir, crd_path])) }}"
+
+    - name: Ensure specified namespace is present
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: '{{ namespace }}'
+
+    - name: Create RBAC resources
+      k8s:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
+        namespace: '{{ namespace }}'
+      with_items:
+        - role.yaml
+        - role_binding.yaml
+        - service_account.yaml

--- a/mbox-operator/roles/mbox/README.md
+++ b/mbox-operator/roles/mbox/README.md
@@ -1,0 +1,10 @@
+Role Name
+=========
+
+This role deploys mbbox - only usable in the operator-sdk context.
+
+
+License
+-------
+
+MIT

--- a/mbox-operator/roles/mbox/defaults/main.yml
+++ b/mbox-operator/roles/mbox/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for mbox

--- a/mbox-operator/roles/mbox/handlers/main.yml
+++ b/mbox-operator/roles/mbox/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for mbox

--- a/mbox-operator/roles/mbox/meta/main.yml
+++ b/mbox-operator/roles/mbox/meta/main.yml
@@ -1,0 +1,62 @@
+galaxy_info:
+  author: CPE Team
+  description: Mbox Operator
+  company: Red Hat
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: MIT
+
+  min_ansible_version: 2.9
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  # github_branch:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+  # List tags for your role here, one per line. A tag is a keyword that describes
+  # and categorizes the role. Users find roles by searching for tags. Be sure to
+  # remove the '[]' above, if you add tags to this list.
+  #
+  # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+  #       Maximum 20 tags per role.
+
+dependencies: []
+# List your role dependencies here, one per line. Be sure to remove the '[]' above,
+# if you add dependencies to this list.
+collections:
+  - operator_sdk.util

--- a/mbox-operator/roles/mbox/tasks/main.yml
+++ b/mbox-operator/roles/mbox/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+# tasks file for mbox
+- name: start memcached
+  k8s:
+    definition:
+      kind: Deployment
+      apiVersion: apps/v1
+      metadata:
+        name: '{{ meta.name }}-memcached'
+        namespace: '{{ meta.namespace }}'
+      spec:
+        replicas: "{{size}}"
+        selector:
+          matchLabels:
+            app: memcached
+        template:
+          metadata:
+            labels:
+              app: memcached
+          spec:
+            containers:
+              - name: memcached
+                command:
+                  - memcached
+                  - -m=64
+                  - -o
+                  - modern
+                  - -v
+                image: "docker.io/memcached:1.4.36-alpine"
+                ports:
+                  - containerPort: 11211

--- a/mbox-operator/roles/mbox/vars/main.yml
+++ b/mbox-operator/roles/mbox/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for mbox

--- a/mbox-operator/watches.yaml
+++ b/mbox-operator/watches.yaml
@@ -1,0 +1,5 @@
+---
+- version: v1alpha1
+  group: apps.fedoraproject.org
+  kind: Mbox
+  role: /opt/ansible/roles/mbox


### PR DESCRIPTION
# MBox Operator

Fixes: #15

## Description

Adds the basic structure for the mbox ansible based operator.

It will create a memcached deployment object when a mbox custom resource is created just for bootstrap/example purposes for the first PR.

## Verification

```
kubectl apply -f deploy/crds/deploy/crds/apps.fedoraproject.org_mboxes_crd.yaml
kubectl apply -f deploy/
```

Checking if the operator is successfully running:

```
$ kubectl get pods -w
NAME                              READY   STATUS    RESTARTS   AGE
mbox-operator-6867d56dd4-q2ddq   2/2     Running   0          11m
```

Creating a mbox resource:

```
kubectl apply -f deploy/crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml
```

Editing the `size` property from the mbox resource (`kubectl edit mbox/example-mbox`) will reflect on memcached replicas and deleting it should delete the memcached pod as well.