### PR TITLE
test-cluster

### DIFF
--- a/mbox-operator/deploy/cluster_role_binding.yaml
+++ b/mbox-operator/deploy/cluster_role_binding.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mbox-operator-storage-read
+rules:
+  - apiGroups: [""]
+    resources:
+      - persistentvolumes
+    verbs: ["*"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: mbox-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: mbox-operator-storage-read
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:masters

--- a/mbox-operator/deploy/operator.yaml.j2
+++ b/mbox-operator/deploy/operator.yaml.j2
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mbox-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mbox-operator
+  template:
+    metadata:
+      labels:
+        name: mbox-operator
+    spec:
+      serviceAccountName: mbox-operator
+      containers:
+        - name: ansible
+          command:
+            - /usr/local/bin/ao-logs
+            - /tmp/ansible-operator/runner
+            - stdout
+          # Replace this with the built image name
+          image: "{{ REPLACE_IMAGE }}"
+          imagePullPolicy: "{{ pull_policy|default('Always') }}"
+          volumeMounts:
+            - mountPath: /tmp/ansible-operator/runner
+              name: runner
+              readOnly: true
+        - name: operator
+          # Replace this with the built image name
+          image: "{{ REPLACE_IMAGE }}"
+          imagePullPolicy: "{{ pull_policy|default('Always') }}"
+          volumeMounts:
+            - mountPath: /tmp/ansible-operator/runner
+              name: runner
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "mbox-operator"
+            - name: ANSIBLE_GATHERING
+              value: explicit
+      volumes:
+        - name: runner
+          emptyDir: {}

--- a/mbox-operator/molecule/test-cluster/converge.yml
+++ b/mbox-operator/molecule/test-cluster/converge.yml
@@ -3,31 +3,6 @@
 - name: Converge
   hosts: localhost
   connection: local
-  vars:
-    ansible_python_interpreter: '{{ ansible_playbook_python }}'
-    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
-    image_name: apps.fedoraproject.org/mbox-operator:testing
-    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml'])) | from_yaml }}"
   tasks:
-    - name: Create the apps.fedoraproject.org/v1alpha1.Mbox
-      k8s:
-        namespace: '{{ namespace }}'
-        definition: "{{ lookup('file', '/'.join([deploy_dir, 'crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml'])) }}"
-
-    - name: Get the newly created Custom Resource
-      debug:
-        msg: "{{ lookup('k8s', group='apps.fedoraproject.org', api_version='v1alpha1', kind='Mbox', namespace=namespace, resource_name=custom_resource.metadata.name) }}"
-
-    - name: Wait 2m for reconciliation to run
-      k8s_info:
-        api_version: 'v1alpha1'
-        kind: 'Mbox'
-        namespace: '{{ namespace }}'
-        name: '{{ custom_resource.metadata.name }}'
-      register: reconcile_cr
-      until:
-        - "'Successful' in (reconcile_cr | json_query('resources[].status.conditions[].reason'))"
-      delay: 12
-      retries: 10
-
-- import_playbook: '{{ playbook_dir }}/../default/asserts.yml'
+    - debug:
+        msg: add tasks here

--- a/mbox-operator/molecule/test-cluster/destroy.yml
+++ b/mbox-operator/molecule/test-cluster/destroy.yml
@@ -1,0 +1,75 @@
+---
+- name: Prepare operator resources
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+  tasks:
+    - name: Create temp dir
+      file:
+        state: directory
+        path: "{{ tmpdir }}"
+
+    - name: Process operator template
+      template:
+        src: '{{ deploy_dir }}/operator.yaml.j2'
+        dest: "{{ tmpdir }}/operator.yaml"
+      vars:
+        REPLACE_IMAGE: "{{ operator_image }}"
+
+    - name: Destroy operator deployment
+      k8s:
+        definition: "{{ lookup('file', tmpdir + '/operator.yaml') }}"
+        namespace: "{{ namespace }}"
+        state: absent
+        wait: true
+
+    - name: Wait until pod is gone
+      k8s_info:
+        api_version: v1
+        kind: Pod
+        namespace: "{{ namespace }}"
+        label_selectors:
+          - name=mbox-operator
+      register: _status
+      until: _status.resources|length == 0
+      retries: 60
+      delay: 10
+      ignore_errors: yes
+
+    - name: Destroy Custom Resource Definition
+      k8s:
+        definition: "{{ lookup('file', item) }}"
+        state: absent
+        wait: true
+      with_fileglob:
+        - "{{ deploy_dir }}/crds/apps.fedoraproject.org_*_crd.yaml"
+
+    - name: Destroy RBAC resources
+      k8s:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
+        namespace: '{{ namespace }}'
+        state: absent
+        wait: true
+      with_items:
+        - role.yaml
+        - role_binding.yaml
+        - service_account.yaml
+
+    - name: Destroy cluster RBAC resources
+      k8s:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
+        state: absent
+        wait: true
+      with_items:
+        - cluster_role_binding.yaml
+
+    - name: Destroy namespace
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: '{{ namespace }}'
+        state: absent
+        wait: true
+

--- a/mbox-operator/molecule/test-cluster/molecule.yml
+++ b/mbox-operator/molecule/test-cluster/molecule.yml
@@ -6,9 +6,8 @@ driver:
   options:
     managed: true
     ansible_connection_options: {}
-lint:
-  name: yamllint
-  enabled: false
+lint: |
+  yamllint roles/
 platforms:
   - name: test-cluster
     groups:
@@ -19,6 +18,8 @@ provisioner:
     group_vars:
       all:
         namespace: ${TEST_NAMESPACE:-osdk-test}
+        tmpdir: /tmp/mbox
+        operator_image: quay.io/fedora/mbox-operator:latest
   lint:
     name: ansible-lint
     enabled: false
@@ -31,7 +32,8 @@ scenario:
     - destroy
     - dependency
     - syntax
-    - create
+    # add a create playbook to create crs
+    # - create
     - prepare
     - converge
     - side_effect
@@ -39,5 +41,5 @@ scenario:
     - destroy
 verifier:
   name: testinfra
-  lint:
-    name: flake8
+  lint: |
+    flake8

--- a/mbox-operator/molecule/test-cluster/prepare.yml
+++ b/mbox-operator/molecule/test-cluster/prepare.yml
@@ -1,0 +1,40 @@
+---
+- name: Prepare operator resources
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+  tasks:
+    - name: Create Custom Resource Definition
+      k8s:
+        definition: "{{ lookup('file', item) }}"
+      with_fileglob:
+        - "{{ deploy_dir }}/crds/apps.fedoraproject.org_*_crd.yaml"
+
+    - name: Ensure specified namespace is present
+      k8s:
+        api_version: v1
+        kind: Namespace
+        name: '{{ namespace }}'
+
+    - name: Create RBAC resources
+      k8s:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
+        namespace: '{{ namespace }}'
+      with_items:
+        - role.yaml
+        - role_binding.yaml
+        - service_account.yaml
+
+    - name: Create cluster RBAC resources
+      k8s:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
+      with_items:
+        - cluster_role_binding.yaml
+
+    - name: Create operator deployment
+      k8s:
+        definition: "{{ lookup('file', tmpdir + '/operator.yaml') }}"
+        namespace: "{{ namespace }}"
+        wait: true


### PR DESCRIPTION
Adds basic structure for the test-cluster molecule case:

```sh
molecule test -s test-cluster
```

It doesn't build an image since it should pull an external published image to run al tests.

ping @Zlopez 