### PR TITLE
Added config for Zuul CI

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,13 @@
+- job:
+    name: test-cluster
+    run: ci/test-cluster.yml
+    nodeset: fedora-30-vm
+- job:
+    name: test-local
+    run: ci/test-local.yml
+    nodeset: fedora-30-vm
+- project:
+    check:
+      jobs:
+        - test-cluster
+

--- a/ci/test-cluster.yml
+++ b/ci/test-cluster.yml
@@ -1,0 +1,37 @@
+ - hosts: all
+   tasks:
+    - name: List project directory on the test system
+      command: ls -al {{ansible_user_dir}}/{{zuul.project.src_dir}}
+    - name: Install dependencies
+      become: true
+      package:
+        name: ['git', 'moby-engine', 'python3-pip', 'container-selinux', 'selinux-policy-base']
+        state: present
+    - name: Install k3s selinux settings
+      become: true
+      dnf:
+        name: https://rpm.rancher.io/k3s-selinux-0.1.1-rc1.el7.noarch.rpm
+        state: present
+    - name: Install test deps through pip
+      become: true
+      pip:
+        name: ['molecule', 'kubernetes', 'openshift', 'docker', 'jmespath', 'yamllint']
+    - name: Get k3d install script
+      get_url: url=https://raw.githubusercontent.com/rancher/k3s/master/install.sh dest=/tmp mode='0777'
+    - name: Install k3s
+      command: /tmp/install.sh
+      become: true
+    - name: Wait for port 6443
+      wait_for:
+        port: 6443
+        delay: 40
+    - name: Copy k3s config
+      command: cp /etc/rancher/k3s/k3s.yaml /tmp/k3s.yaml
+      become: true
+    - name: Make k3s config publicly accessible
+      command: chmod 777 /tmp/k3s.yaml 
+      become: true
+    - name: Run molecule test-cluster
+      command: chdir={{ansible_user_dir}}/{{zuul.project.src_dir}}/mbox-operator molecule --debug test -s test-cluster
+      environment: 
+        KUBECONFIG: "/tmp/k3s.yaml"

--- a/ci/test-local.yml
+++ b/ci/test-local.yml
@@ -1,0 +1,15 @@
+ - hosts: all
+   tasks:
+    - name: List project directory on the test system
+      command: ls -al {{ansible_user_dir}}/{{zuul.project.src_dir}}
+    - name: Install git, pip and podman
+      become: true
+      package:
+        name: ['git', 'podman', 'python3-pip']
+        state: present
+    - name: Install libraries through pip 
+      become: true
+      pip:
+        name: ['molecule', 'kubernetes', 'openshift', 'docker', 'jmespath', 'yamllint']
+    - name: Run molecule 
+      command: chdir={{ansible_user_dir}}/{{zuul.project.src_dir}}/mbox-operator molecule --debug test -s test-local

--- a/mbox-operator/molecule/test-cluster/destroy.yml
+++ b/mbox-operator/molecule/test-cluster/destroy.yml
@@ -1,6 +1,7 @@
 ---
 - name: Destroy operator resources
   hosts: localhost
+  gather_facts: false
   connection: local
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
@@ -18,6 +19,7 @@
         dest: "{{ tmpdir }}/operator.yaml"
       vars:
         REPLACE_IMAGE: "{{ operator_image }}"
+        pull_policy: Always
 
     - name: Destroy koji-hub custom resource
       k8s:
@@ -67,14 +69,6 @@
         - role.yaml
         - role_binding.yaml
         - service_account.yaml
-
-    - name: Destroy cluster RBAC resources
-      k8s:
-        definition: "{{ lookup('template', '/'.join([deploy_dir, item])) }}"
-        state: absent
-        wait: true
-      with_items:
-        - cluster_role_binding.yaml
 
     - name: Destroy namespace
       k8s:

--- a/mbox-operator/molecule/test-cluster/prepare.yml
+++ b/mbox-operator/molecule/test-cluster/prepare.yml
@@ -1,6 +1,7 @@
 ---
 - name: Prepare operator resources
   hosts: localhost
+  gather_facts: false
   connection: local
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}'


### PR DESCRIPTION
Because jenkins-fedora-apps.apps.ci.centos.org doesn't have working cico nodes yet and we need a VM for spawning the kubernetes cluster, I opted to try to prototype the PR check on Zuul.

Closes #22 