### PR TITLE
tls support

### DIFF
--- a/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojihub_cr.yaml
+++ b/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojihub_cr.yaml
@@ -7,13 +7,14 @@ metadata:
 spec:
   replicas: 1
   persistent: true
-  host: ''
+  host: 'mbox.dev'
   configmap: koji-hub
-  cacert_secret: cacert
-  service_cert_secret: service-cert
+  ca_cert_secret: koji-hub-ca-cert
+  service_cert_secret: koji-hub-service-cert
   postgres_secret: postgres
   http_enabled: true
   https_enabled: true
   topic_prefix: mbox_dev
   fedora_messaging_url: amqps://koji:something@rabbitmq
   messaging_cert_cm: koji-hub-msg
+  ingress_backend: nginx

--- a/mbox-operator/molecule/default/asserts/koji-hub.yml
+++ b/mbox-operator/molecule/default/asserts/koji-hub.yml
@@ -5,8 +5,6 @@
   connection: local
   vars:
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
-    koji_configmap: koji-hub-configmap
-    kojihub_cacert_secret: cacert
   tasks:
       - block:
         - name: 'TEST: koji_hub.configmap'
@@ -14,7 +12,7 @@
             api_version: v1
             kind: ConfigMap
             namespace: "{{ namespace }}"
-            name: "{{ koji_configmap }}"
+            name: koji-hub
           register: koji_configmap
         - assert:
             that:
@@ -26,18 +24,33 @@
               - "'fedora-messaging.toml' in koji_configmap.resources[0].data"
 
       - block:
-          - name: 'TEST: kojihub.secret.cacert'
+          - name: 'TEST: kojihub.secret.koji-hub-ca-cert'
             k8s_info:
               api_version: v1
               kind: Secret
               namespace: "{{ namespace }}"
-              name: "{{ kojihub_cacert_secret }}"
+              name: koji-hub-ca-cert
             register: kojihub_secrets
           - assert:
               that:
                 - kojihub_secrets.resources|length == 1                
                 - kojihub_secrets.resources[0].metadata.labels['app'] == 'koji-hub'
                 - "'cert' in kojihub_secrets.resources[0].data"
+
+      - block:
+          - name: 'TEST: kojihub.secret.koji-hub-service-cert'
+            k8s_info:
+              api_version: v1
+              kind: Secret
+              namespace: "{{ namespace }}"
+              name: koji-hub-service-cert
+            register: kojihub_secrets
+          - assert:
+              that:
+                - kojihub_secrets.resources|length == 1                
+                - kojihub_secrets.resources[0].metadata.labels['app'] == 'koji-hub'
+                - "'tls.crt' in kojihub_secrets.resources[0].data"
+                - "'tls.key' in kojihub_secrets.resources[0].data"
 
       - block:
           - name: 'TEST: kojihub.pvcs'

--- a/mbox-operator/roles/koji-hub/defaults/main.yml
+++ b/mbox-operator/roles/koji-hub/defaults/main.yml
@@ -1,22 +1,24 @@
 ---
 # defaults file for koji-hub
-koji_hub_image: quay.io/fedora/koji-hub:latest
-koji_hub_replicas: 1
+koji_hub_image: "{{ image | default('quay.io/fedora/koji-hub:latest') }}"
+koji_hub_replicas: "{{ replicas | default(1) }}"
 
-koji_hub_configmap: koji-hub-configmap
-koji_hub_cacert_secret: koji-hub-cacert
-koji_hub_service_cert_secret: "{{ service_cert_secret | default('service-cert') }}"
+koji_hub_configmap: "{{ configmap | default('koji-hub-configmap') }}"
+koji_hub_ca_cert_secret: "{{ ca_cert_secret | default('koji-hub-ca-cert') }}"
+koji_hub_service_cert_secret: "{{ service_cert_secret | default('koji-hub-service-cert') }}"
 koji_hub_messaging_cert_cm: "{{ messaging_cert_cm | default('koji-hub-msg') }}"
 
-koji_hub_httpd_pvc_name: koji-hub-httpd-pvc
-koji_hub_httpd_pvc_size: 1Gi
+koji_hub_httpd_pvc_name: "{{ httpd_pvc_name | default('koji-hub-httpd-pvc') }}"
+koji_hub_httpd_pvc_size: "{{ httpd_pvc_size | default('1Gi') }}"
 
-koji_hub_mnt_pvc_name: koji-hub-mnt-pvc
-koji_hub_mnt_pvc_size: 10Gi
+koji_hub_mnt_pvc_name: "{{ mnt_pvc_name | default('koji-hub-mnt-pvc') }}"
+koji_hub_mnt_pvc_size: "{{ mnt_pvc_size | default('10Gi') }}"
 
-koji_hub_http_port: "8080"
-koji_hub_https_port: "8443"
-koji_hub_svc_name: koji-hub
-koji_hub_http_enabled: "{{ http_enabled|default(false) }}"
-koji_hub_https_enabled: "{{ https_enabled|default(true) }}"
-koji_hub_host: "{{ host|default('kojihub.mbox.dev') }}"
+koji_hub_http_port: "{{ http_port | default('8080') }}"
+koji_hub_https_port: "{{ https_port | default('8443') }}"
+koji_hub_svc_name: "{{ svc_name | default('koji-hub') }}"
+koji_hub_http_enabled: "{{ http_enabled | default(false) }}"
+koji_hub_https_enabled: "{{ https_enabled | default(true) }}"
+koji_hub_host: "{{ host | default('kojihub.mbox.dev') }}"
+
+koji_hub_ingress_backend: "{{ ingress_backend | default('nginx') }}"

--- a/mbox-operator/roles/koji-hub/tasks/cert.yml
+++ b/mbox-operator/roles/koji-hub/tasks/cert.yml
@@ -1,46 +1,80 @@
-- openssl_privatekey:
-    path: /tmp/{{ cert_name }}.pem
-    size: 4096
+- set_fact:
+    cert_name: foobar
 
-- openssl_csr:
-    path: /tmp/{{ cert_name }}.csr
-    privatekey_path: /tmp/{{ cert_name }}.pem
+- name: Root CA creation
+  block:
+    - openssl_privatekey:
+        path: /tmp/{{ cert_name }}_ca_key.pem
+        size: 4096
+    - openssl_csr:
+        path: /tmp/{{ cert_name }}_ca_req.csr
+        privatekey_path: /tmp/{{ cert_name }}_ca_key.pem
+        common_name: "{{ koji_hub_host }}"
+    - openssl_certificate:
+        path: /tmp/{{ cert_name }}_ca_cert.crt
+        privatekey_path: /tmp/{{ cert_name }}_ca_key.pem
+        csr_path: /tmp/{{ cert_name }}_ca_req.csr
+        provider: selfsigned
 
-- openssl_certificate:
-    path: /tmp/{{ cert_name }}.crt
-    privatekey_path: /tmp/{{ cert_name }}.pem
-    csr_path: /tmp/{{ cert_name }}.csr
-    provider: selfsigned
+- name: Server certificate creation
+  block:
+    - openssl_privatekey:
+        path: /tmp/{{ cert_name }}_server_key.pem
+        size: 4096
+    - openssl_csr:
+        path: /tmp/{{ cert_name }}_server_req.csr
+        privatekey_path: /tmp/{{ cert_name }}_server_key.pem
+        common_name: "{{ koji_hub_host }}"
+    - openssl_certificate:
+        path: /tmp/{{ cert_name }}_server_cert.crt
+        csr_path: /tmp/{{ cert_name }}_server_req.csr
+        ownca_path: /tmp/{{ cert_name }}_ca_cert.crt
+        ownca_privatekey_path: /tmp/{{ cert_name }}_ca_key.pem
+        provider: ownca
 
-- template:
-    src: cert-secret.yml.j2
-    dest: /tmp/cert-secret.yml
-  vars:
-    ca_data: "{{ lookup('file', '/tmp/' + cert_name + '.crt') }}"
-    cert_data: "{{ lookup('file', '/tmp/' + cert_name + '.crt') }}"
-    key_data: "{{ lookup('file', '/tmp/' + cert_name + '.pem') }}"
+- name: Kubernetes root ca secret creation
+  block:
+    - k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ koji_hub_ca_cert_secret }}"
+        namespace: "{{ meta.namespace }}"
+      register: cacert_query
+    - k8s:
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ koji_hub_ca_cert_secret }}"
+            namespace: "{{ meta.namespace }}"
+            labels:
+              app: koji-hub
+          data:
+            csr: "{{ lookup('file', '/tmp/' + cert_name + '_server_req.csr') | b64encode }}"
+            cert: "{{ lookup('file', '/tmp/' + cert_name + '_ca_cert.crt') | b64encode }}"
+            key: "{{ lookup('file', '/tmp/' + cert_name + '_ca_key.pem') | b64encode }}"
+      when: cacert_query.resources|length == 0
 
-- k8s:
-    state: present
-    src: /tmp/cert-secret.yml
-    wait: true
-    namespace: "{{ meta.namespace }}"
 
-- k8s_info:
-    api_version: v1
-    kind: Secret
-    name: "{{ cert_name }}"
-    namespace: "{{ meta.namespace }}"
-  register: kojihub_ca_secret
-  until: kojihub_ca_secret.resources|length > 0
-  delay: 3
-  retries: 10
-
-- file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - /tmp/cert-secret.yml
-    - /tmp/{{ cert_name }}.pem
-    - /tmp/{{ cert_name }}.crt
-    - /tmp/{{ cert_name }}.csr
+- name: Kubernetes server certificate secret creation
+  block:
+    - k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ koji_hub_service_cert_secret }}"
+        namespace: "{{ meta.namespace }}"
+      register: servicecert_query
+    - k8s:
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ koji_hub_service_cert_secret }}"
+            namespace: "{{ meta.namespace }}"
+            labels:
+              app: koji-hub
+          data:
+            tls.crt: "{{ lookup('file', '/tmp/' + cert_name + '_server_cert.crt') | b64encode }}"
+            tls.key: "{{ lookup('file', '/tmp/' + cert_name + '_server_key.pem') | b64encode }}"
+          type: kubernetes.io/tls
+      when: servicecert_query.resources|length == 0

--- a/mbox-operator/roles/koji-hub/tasks/main.yml
+++ b/mbox-operator/roles/koji-hub/tasks/main.yml
@@ -48,37 +48,7 @@
         path: /tmp/configmap.yml
         state: absent
 
-- block:
-    - name: Ensure cacert exists
-      k8s_info:
-        api_version: v1
-        kind: Secret
-        name: "{{ cacert_secret | default(koji_hub_cacert_secret) }}"
-        namespace: "{{ meta.namespace }}"
-      register: k8s_cacert
-
-    - include_tasks: cert.yml
-      vars:
-        cert_name: "{{ cacert_secret | default(koji_hub_cacert_secret) }}"
-        cert_key_name: cert
-        pk_key_name: key
-      when: k8s_cacert.resources|length == 0
-
-- block:
-    - name: Ensure service cert exists
-      k8s_info:
-        api_version: v1
-        kind: Secret
-        name: "{{ service_cert_secret | default(koji_hub_service_cert_secret) }}"
-        namespace: "{{ meta.namespace }}"
-      register: k8s_cacert
-
-    - include_tasks: cert.yml
-      vars:
-        cert_name: "{{ service_cert_secret | default(koji_hub_service_cert_secret) }}"
-        cert_key_name: tls.crt
-        pk_key_name: tls.key
-      when: k8s_cacert.resources|length == 0
+- include_tasks: cert.yml
 
 - name: PVC creation
   include_tasks: pvc.yml

--- a/mbox-operator/roles/koji-hub/templates/configmap.yml.j2
+++ b/mbox-operator/roles/koji-hub/templates/configmap.yml.j2
@@ -6,6 +6,7 @@ metadata:
     app: koji-hub
 data:
   httpd.conf: |-
+    ServerName "{{ koji_hub_host }}"
     ServerRoot "/httpdir"
     PidFile "/httpdir/httpd.pid"
     LoadModule authn_file_module modules/mod_authn_file.so
@@ -42,6 +43,25 @@ data:
     AddDefaultCharset UTF-8
     CoreDumpDirectory /tmp
     Listen 0.0.0.0:{{ koji_hub_http_port }} http
+{% if koji_hub_https_enabled %}
+    Listen 0.0.0.0:{{ koji_hub_https_port }} https
+{% endif %}
+
+    <VirtualHost *:{{ koji_hub_http_port }}>
+        ServerName "{{ koji_hub_host }}"
+        TypesConfig /etc/mime.types
+        AddDefaultCharset UTF-8
+    </VirtualHost>
+
+{% if koji_hub_https_enabled %}
+    <VirtualHost *:{{ koji_hub_https_port }}>
+        ServerName "{{ koji_hub_host }}"
+        TypesConfig /etc/mime.types
+        AddDefaultCharset UTF-8
+        SSLEngine on
+        SSLProtocol TLSv1.2
+    </VirtualHost>
+{% endif %}
 
     WSGIDaemonProcess koji_hub display-name=koji_hub processes=2 threads=2 maximum-requests=1000 home=/httpdir
     WSGIPythonPath /usr/share/koji-hub/

--- a/mbox-operator/roles/koji-hub/templates/deployment.yml.j2
+++ b/mbox-operator/roles/koji-hub/templates/deployment.yml.j2
@@ -28,6 +28,7 @@ spec:
             periodSeconds: 15
           ports:
             - containerPort: {{ koji_hub_http_port }}
+            - containerPort: {{ koji_hub_https_port }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/koji-hub
@@ -47,19 +48,19 @@ spec:
       volumes:
         - name: cacert-volume
           secret:
-            secretName: cacert
+            secretName: "{{ koji_hub_ca_cert_secret }}"
         - name: service-cert-volume
           secret:
-            secretName: service-cert
+            secretName: "{{ koji_hub_service_cert_secret }}"
         - name: config-volume
           configMap:
-            name: koji-hub-configmap
+            name: "{{ koji_hub_configmap }}"
         - name: koji-hub-httpd
           persistentVolumeClaim:
-            claimName: koji-hub-httpd-pvc
+            claimName: "{{ koji_hub_httpd_pvc_name }}"
         - name: koji-hub-mnt
           persistentVolumeClaim:
-            claimName: koji-hub-mnt-pvc
+            claimName: "{{ koji_hub_mnt_pvc_name }}"
         - name: koji-hub-msg
           configMap:
             name: {{ koji_hub_messaging_cert_cm }}

--- a/mbox-operator/roles/koji-hub/templates/ingress.yml.j2
+++ b/mbox-operator/roles/koji-hub/templates/ingress.yml.j2
@@ -4,7 +4,21 @@ metadata:
   name: {{ koji_hub_ingress_name }}
   labels:
     app: koji-hub
+{% if koji_hub_ingress_backend == 'nginx' %}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.allow-http: "false"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/secure-backends: "true"
+{% endif %}
 spec:
+{% if koji_hub_https_enabled %}
+  tls:
+  - hosts:
+    - {{ koji_hub_host }}
+    secretName: {{ koji_hub_service_cert_secret }}
+{% endif %}
   rules:
     - http:
         paths:
@@ -12,4 +26,4 @@ spec:
             pathType: Prefix
             backend:
               serviceName: {{ koji_hub_ingress_svc }}
-              servicePort: {{ koji_hub_ingress_port }}
+              servicePort: {{ koji_hub_http_port }}


### PR DESCRIPTION
fixes #26

This PR enables TLS for both internal service and ingress.

## Verification

### Tests

Run one of the following commands:

* `operator-sdk test local`
* `molecule test -s test-local`

### Deployment

* Change "host" value in mbkojihub mbox CR to the correct app host;
* Build an image, push it and  change the image name in `deploy/operator.yaml`
* Optional: enable ingress addon if using minikube
* Deploy both operator and CR;
* Wait for your ingress to be available (aka show an address) and test it with curl: `curl -k https://$ADDR/kojihub`