### PR TITLE
docs setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ state/
 mbox/__pycache__
 openshift.local.clusterup/
 .vagrant/
+docs/build

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
+![rtd status](https://mbbox-operator.readthedocs.io/en/latest/)
+
 # mbox
 Module Building in a Box
 
 This repository contains a set of scripts used to set up a buildsystem that can be used for Fedora/RHEL Modular packages, based on [Koji](https://pagure.io/koji/) and [Module Build Service](https://pagure.io/fm-orchestrator/).
 
 The intention is for it to be trivially simple to get started with both, but also allow the same setup to be used for a production setup.
+
+Full documentation can be found at: https://mbbox-operator.readthedocs.io/en/latest/
 
 ## Usage
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,26 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@make clean
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+
+.PHONY: clean
+clean:
+	rm -rf $(BUILDDIR)/*

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,76 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'mbox-operator'
+copyright = '2019, Red Hat, Inc. and others'
+author = 'Red Hat, Inc. and others'
+
+# The full version, including alpha/beta/rc tags
+release = '0.0.1'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+  "sphinx.ext.autosummary",
+  "sphinx.ext.doctest",
+  "sphinx.ext.intersphinx",
+  "sphinx.ext.viewcode",
+  "sphinx.ext.napoleon"
+]
+
+autosummary_generate = True
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# source_suffix = ['.rst', '.md']
+source_suffix = ".rst"
+
+# The master toctree document.
+master_doc = "index"
+
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+html_theme_options = {
+  "logo_name": True,
+  "github_user": "fedora-infra",
+  "github_repo": "mbbox",
+  "page_width": "1040px",
+}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,0 +1,43 @@
+============
+Contributing
+============
+
+Mbox welcomes contributions! Our issue tracker is located on `GitHub <https://github.com/fedora-infra/mbbox/issues>`_.
+
+Guidelines
+===========
+
+When you make a pull request, someone from the fedora organization
+will review your code. Please make sure you follow the guidelines below:
+
+Code Style
+----------
+
+Make sure your yaml code passes our yamllint rules.
+
+E2E Tests
+---------
+
+Every change should be tested in molecule, which is the tool we use for E2E (end to end) testing.
+
+Tests can be run using either molecule or operator-sdk cli (which uses molecule as well).
+
+.. code-block:: bash
+
+  molecule test -s test-local #local tests, no need for a cluster
+  molecule test -s test-cluster #needs a remote cluster, minikube is enough
+  operator-sdk test local #runs local tests as well, just a molecule cli wrapper
+
+Environment
+===========
+
+We are providing a full development environment in Vagrant but you can use your host machine as long as you meet the following requirements:
+
+* ansible >= 2.9
+* molecule >= 3
+* yamllint >= 1.20
+* python kubernetes and openshift libraries
+* operator-sdk >= 0.16
+* docker >= 19
+
+NOTE: make sure both ansible and molecule are system-wide installed using in the same python interpreter otherwise you may have issues running tests.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,21 @@
+.. mbox-operator documentation master file, created by
+   sphinx-quickstart on Thu Apr 23 13:01:40 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+mbox-operator
+=============
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   contributing
+
+
+
+Module Building in a Box (MBBOX) Kubernetes Operator
+
+MBOX is a kubernetes operator used to set up a buildsystem that can be used for Fedora/RHEL Modular packages, based on Koji and Module Build Service.
+
+The intention is for it to be trivially simple to get started with both, but also allow the same setup to be used for a production setup.


### PR DESCRIPTION
fixes #31 

This PR creates the basic structure for the operator documentation.

## Changes

* Added a doc folder containing a sphinx project in rst format;
* Run `make html` to build its html documentation within the `docs` folder;