### PR TITLE
tls ca fix

### DIFF
--- a/images/koji-hub/Dockerfile
+++ b/images/koji-hub/Dockerfile
@@ -2,12 +2,15 @@ FROM fedora:31
 
 RUN dnf install --setopt tsflags= -y \
 koji koji-hub koji-web koji-hub-plugins \
-curl httpd mod_ssl postgresql fedora-messaging python3-mod_wsgi 
+curl httpd mod_ssl postgresql fedora-messaging python3-mod_wsgi
 
 RUN curl https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/roles/koji_hub/templates/fedmsg-koji-plugin.py -o /usr/lib/koji-hub-plugins/fedmsg-koji-plugin.py
 RUN rm -f /etc/kojiweb/web.conf && \
 ln -s /etc/koji-hub/kojiweb.conf /etc/kojiweb/web.conf
-RUN chown -R 1001:root /etc/koji-hub
+RUN chown -R 1001:root /etc/koji-hub && \
+chown -R 1001:root /etc/pki/tls
+RUN mkdir -p /var/cache/kojihub && \
+chown -R 1001:root /var/cache/kojihub
 
 COPY readiness.sh /readiness.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/images/koji-hub/readiness.sh
+++ b/images/koji-hub/readiness.sh
@@ -5,7 +5,7 @@ BODY='<?xml version="1.0" encoding="utf-8"?><methodCall><methodName>system.listM
 res=$(curl \
 -X POST \
 -H 'Content-Type: text/xml' \
--d '$BODY' \
+-d "$BODY" \
 http://127.0.0.1:8080/kojihub/)
 
 if [ "$?" != '0' ]

--- a/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojihub_cr.yaml
+++ b/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojihub_cr.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: mb-koji-hub
 spec:
+  image: quay.io/fedora/koji-hub:latest
   replicas: 1
   persistent: true
   host: 'mbox.dev'

--- a/mbox-operator/roles/koji-hub/defaults/main.yml
+++ b/mbox-operator/roles/koji-hub/defaults/main.yml
@@ -3,6 +3,8 @@
 koji_hub_image: "{{ image | default('quay.io/fedora/koji-hub:latest') }}"
 koji_hub_replicas: "{{ replicas | default(1) }}"
 
+koji_hub_postgres_secret: "{{ postgres_secret | default('postgres') }}"
+
 koji_hub_configmap: "{{ configmap | default('koji-hub-configmap') }}"
 koji_hub_ca_cert_secret: "{{ ca_cert_secret | default('koji-hub-ca-cert') }}"
 koji_hub_service_cert_secret: "{{ service_cert_secret | default('koji-hub-service-cert') }}"

--- a/mbox-operator/roles/koji-hub/tasks/cert.yml
+++ b/mbox-operator/roles/koji-hub/tasks/cert.yml
@@ -1,35 +1,49 @@
-- set_fact:
-    cert_name: foobar
+- name: create temporary cert directory
+  tempfile:
+    state: directory
+    prefix: kojihub
+    suffix: cert
+  register: cert_dir
 
 - name: Root CA creation
   block:
     - openssl_privatekey:
-        path: /tmp/{{ cert_name }}_ca_key.pem
+        path: "{{ cert_dir.path }}/ca_key.pem"
         size: 4096
     - openssl_csr:
-        path: /tmp/{{ cert_name }}_ca_req.csr
-        privatekey_path: /tmp/{{ cert_name }}_ca_key.pem
+        path: "{{ cert_dir.path }}/ca_req.pem"
+        privatekey_path: "{{ cert_dir.path }}/ca_key.pem"
         common_name: "{{ koji_hub_host }}"
+        create_subject_key_identifier: true
+        key_usage:
+          - cRLSign
+          - dataEncipherment
+          - digitalSignature
+          - keyCertSign
+          - keyEncipherment
+          - nonRepudiation
+        basic_constraints:
+          - 'CA:TRUE'
     - openssl_certificate:
-        path: /tmp/{{ cert_name }}_ca_cert.crt
-        privatekey_path: /tmp/{{ cert_name }}_ca_key.pem
-        csr_path: /tmp/{{ cert_name }}_ca_req.csr
+        path: "{{ cert_dir.path }}/ca_cert.pem"
+        privatekey_path: "{{ cert_dir.path }}/ca_key.pem"
+        csr_path: "{{ cert_dir.path }}/ca_req.pem"
         provider: selfsigned
 
 - name: Server certificate creation
   block:
     - openssl_privatekey:
-        path: /tmp/{{ cert_name }}_server_key.pem
+        path: "{{ cert_dir.path }}/server_key.pem"
         size: 4096
     - openssl_csr:
-        path: /tmp/{{ cert_name }}_server_req.csr
-        privatekey_path: /tmp/{{ cert_name }}_server_key.pem
+        path: "{{ cert_dir.path }}/server_req.pem"
+        privatekey_path: "{{ cert_dir.path }}/server_key.pem"
         common_name: "{{ koji_hub_host }}"
     - openssl_certificate:
-        path: /tmp/{{ cert_name }}_server_cert.crt
-        csr_path: /tmp/{{ cert_name }}_server_req.csr
-        ownca_path: /tmp/{{ cert_name }}_ca_cert.crt
-        ownca_privatekey_path: /tmp/{{ cert_name }}_ca_key.pem
+        path: "{{ cert_dir.path }}/server_cert.pem"
+        csr_path: "{{ cert_dir.path }}/server_req.pem"
+        ownca_path: "{{ cert_dir.path }}/ca_cert.pem"
+        ownca_privatekey_path: "{{ cert_dir.path }}/ca_key.pem"
         provider: ownca
 
 - name: Kubernetes root ca secret creation
@@ -50,9 +64,9 @@
             labels:
               app: koji-hub
           data:
-            csr: "{{ lookup('file', '/tmp/' + cert_name + '_server_req.csr') | b64encode }}"
-            cert: "{{ lookup('file', '/tmp/' + cert_name + '_ca_cert.crt') | b64encode }}"
-            key: "{{ lookup('file', '/tmp/' + cert_name + '_ca_key.pem') | b64encode }}"
+            csr: "{{ lookup('file', cert_dir.path + '/server_req.pem') | b64encode }}"
+            cert: "{{ lookup('file', cert_dir.path + '/ca_cert.pem') | b64encode }}"
+            key: "{{ lookup('file', cert_dir.path + '/ca_key.pem') | b64encode }}"
       when: cacert_query.resources|length == 0
 
 
@@ -74,7 +88,12 @@
             labels:
               app: koji-hub
           data:
-            tls.crt: "{{ lookup('file', '/tmp/' + cert_name + '_server_cert.crt') | b64encode }}"
-            tls.key: "{{ lookup('file', '/tmp/' + cert_name + '_server_key.pem') | b64encode }}"
+            tls.crt: "{{ lookup('file', cert_dir.path + '/server_cert.pem') | b64encode }}"
+            tls.key: "{{ lookup('file', cert_dir.path + '/server_key.pem') | b64encode }}"
           type: kubernetes.io/tls
       when: servicecert_query.resources|length == 0
+
+- name: cleanup
+  file:
+    path: "{{ cert_dir.path }}"
+    state: absent

--- a/mbox-operator/roles/koji-hub/templates/deployment.yml.j2
+++ b/mbox-operator/roles/koji-hub/templates/deployment.yml.j2
@@ -29,6 +29,9 @@ spec:
           ports:
             - containerPort: {{ koji_hub_http_port }}
             - containerPort: {{ koji_hub_https_port }}
+          envFrom:
+            - secretRef:
+                name: {{ koji_hub_postgres_secret }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/koji-hub


### PR DESCRIPTION
fixes #59 

## Changes

* re-factors tls cert generation to include CA extensions
* adds psql schema import in koji-hub image
* fixes readiness koji-hub script

NOTE: you will need to build both koji-hub and operator images on your own and change the image reference before deployment or use the following built images:

* quay.io/lrossett/mbox-operator:latest
* quay.io/lrossett/koji-hub:latest

## Verification steps

* Deploy mbox operator and kojihub cr
* "ssh" into the koji-hub pod: `k exec -it koji-hub-6bff9b7544-4jwq7 -- /bin/bash`
* cd into `/tmp` and run the following commands:
  * `openssl genrsa -out client.key 4096`
  * `openssl req -new -key client.key -out client.csr` (skip everything but common name which should be the desired koji username such as "mboxdev")
  * `openssl x509 -req -in client.csr -CA /etc/cacert/cert -CAkey /etc/cacert/key -CAcreateserial -CAserial client.srl -days 730 -sha256 -out client.crt`
  * Run `openssl verify client.crt`, expected output: `client.crt OK`
  * create a `data.xml` file:
    ```xml
    <?xml version="1.0" encoding="utf-8"?>
    <methodCall>
      <methodName>sslLogin</methodName>
      <params>
      </params>
    </methodCall>
    ```
  * run the command: `curl -k -X POST --cert client.crt --key client.key  -d @data.xml https://127.0.0.1:8443/kojihub/ssllogin`, expected output:
    ```xml
    <?xml version='1.0'?>
    <methodResponse>
    <params>
    <param>
    <value><struct>
    <member>
    <name>session-id</name>
    <value><int>1</int></value>
    </member>
    <member>
    <name>session-key</name>
    <value><string>1-4avhfEn8INv0uvUGduA</string></value>
    </member>
    </struct></value>
    </param>
    </params>
    </methodResponse>
    ```