### PR TITLE
Made the default molecule test suite to run lint

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,9 +10,14 @@
     name: test-docs
     run: ci/test-docs.yml
     nodeset: fedora-30-vm
+- job:
+    name: test-lint
+    run: ci/test-default.yml
+    nodeset: fedora-30-vm
 - project:
     check:
       jobs:
         - test-cluster
         - test-docs
+        - test-lint
 

--- a/ci/test-default.yml
+++ b/ci/test-default.yml
@@ -1,0 +1,14 @@
+ - hosts: all
+   tasks:
+    - name: Install dependencies
+      become: true
+      package:
+        name: ['git', 'moby-engine', 'python3-pip', 'container-selinux', 'selinux-policy-base']
+        state: present
+    - name: Install test deps through pip
+      become: true
+      pip:
+        name: ['molecule', 'kubernetes', 'openshift', 'docker', 'jmespath', 'yamllint']
+      become: true
+    - name: Run molecule test (the default only runs lint)
+      command: chdir={{ansible_user_dir}}/{{zuul.project.src_dir}}/mbox-operator molecule test

--- a/mbox-operator/molecule/default/molecule.yml
+++ b/mbox-operator/molecule/default/molecule.yml
@@ -2,23 +2,16 @@
 dependency:
   name: galaxy
 driver:
-  name: docker
-lint:
-  name: yamllint
-  enabled: false
+  name: delegated
+  options:
+    managed: true
+    ansible_connection_options: {}
+lint: |
+  yamllint roles/
 platforms:
   - name: kind-default
     groups:
       - k8s
-    image: bsycorp/kind:latest-1.15
-    privileged: true
-    override_command: false
-    exposed_ports:
-      - 8443/tcp
-      - 10080/tcp
-    published_ports:
-      - 0.0.0.0:${TEST_CLUSTER_PORT:-9443}:8443/tcp
-    pre_build_image: true
 provisioner:
   name: ansible
   log: true
@@ -30,13 +23,12 @@ provisioner:
       all:
         namespace: ${TEST_NAMESPACE:-osdk-test}
   env:
-    K8S_AUTH_KUBECONFIG: /tmp/molecule/kind-default/kubeconfig
-    KUBECONFIG: /tmp/molecule/kind-default/kubeconfig
     ANSIBLE_ROLES_PATH: ${MOLECULE_PROJECT_DIRECTORY}/roles
-    KIND_PORT: '${TEST_CLUSTER_PORT:-9443}'
 scenario:
   name: default
+  test_sequence:
+    - lint
 verifier:
   name: testinfra
-  lint:
-    name: flake8
+  lint: |
+    flake8

--- a/mbox-operator/molecule/test-cluster/molecule.yml
+++ b/mbox-operator/molecule/test-cluster/molecule.yml
@@ -6,8 +6,6 @@ driver:
   options:
     managed: true
     ansible_connection_options: {}
-lint: |
-  yamllint roles/
 platforms:
   - name: test-cluster
     groups:
@@ -28,7 +26,6 @@ provisioner:
 scenario:
   name: test-cluster
   test_sequence:
-    - lint
     - destroy
     - dependency
     - syntax


### PR DESCRIPTION
Made the default molecule test suite to run lint, removed lint from cluster test, added the default test to CI.

Te default test suite was not working anyway, and splitting it sounds useful for CI (i.e. we will see more failures faster, instead of "lint failed" - "push" - "test cluster failed", they will run in paralell) 