### PR TITLE
Update vagrant to support documentation building

### DIFF
--- a/ansible/roles/mbbox-dev/tasks/main.yml
+++ b/ansible/roles/mbbox-dev/tasks/main.yml
@@ -7,7 +7,9 @@
            vim-enhanced,
            python3-black,
            tmux,
-           htop
+           htop,
+           make,
+           python3-sphinx
           ]
     state: present
 


### PR DESCRIPTION
Adding these packages will allow us to build documentation inside vagrant machine.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>