### PR TITLE
Issue 61 user setup

### DIFF
--- a/mbox-operator/build/Dockerfile
+++ b/mbox-operator/build/Dockerfile
@@ -1,5 +1,10 @@
 FROM quay.io/operator-framework/ansible-operator:v0.16.0
 
+USER root
+RUN dnf install gcc libpq libpq-devel python3-devel -y
+RUN pip3.6 install psycopg2
+USER ${USER_ID}
+
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \
     && chmod -R ug+rwx ${HOME}/.ansible

--- a/mbox-operator/roles/koji-hub/defaults/main.yml
+++ b/mbox-operator/roles/koji-hub/defaults/main.yml
@@ -24,3 +24,5 @@ koji_hub_https_enabled: "{{ https_enabled | default(true) }}"
 koji_hub_host: "{{ host | default('kojihub.mbox.dev') }}"
 
 koji_hub_ingress_backend: "{{ ingress_backend | default('nginx') }}"
+
+koji_hub_admin_username: "{{ admin_username | default('kojiadmin') }}"

--- a/mbox-operator/roles/koji-hub/tasks/cert.yml
+++ b/mbox-operator/roles/koji-hub/tasks/cert.yml
@@ -46,6 +46,22 @@
         ownca_privatekey_path: "{{ cert_dir.path }}/ca_key.pem"
         provider: ownca
 
+- name: Admin user certificate creation
+  block:
+    - openssl_privatekey:
+        path: "{{ cert_dir.path }}/admin_key.pem"
+        size: 4096
+    - openssl_csr:
+        path: "{{ cert_dir.path }}/admin_req.pem"
+        privatekey_path: "{{ cert_dir.path }}/admin_key.pem"
+        common_name: "{{ koji_hub_admin_username }}"
+    - openssl_certificate:
+        path: "{{ cert_dir.path }}/admin_cert.pem"
+        csr_path: "{{ cert_dir.path }}/admin_req.pem"
+        ownca_path: "{{ cert_dir.path }}/ca_cert.pem"
+        ownca_privatekey_path: "{{ cert_dir.path }}/ca_key.pem"
+        provider: ownca
+
 - name: Kubernetes root ca secret creation
   block:
     - k8s_info:
@@ -92,6 +108,27 @@
             tls.key: "{{ lookup('file', cert_dir.path + '/server_key.pem') | b64encode }}"
           type: kubernetes.io/tls
       when: servicecert_query.resources|length == 0
+
+- name: Kubernetes admin certificate secret creation
+  block:
+    - k8s_info:
+        api_version: v1
+        kind: Secret
+        name: koji-hub-admin-cert
+        namespace: "{{ meta.namespace }}"
+      register: admin_cert_query
+    - k8s:
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: koji-hub-admin-cert
+            namespace: "{{ meta.namespace }}"
+            labels:
+              app: koji-hub
+          data:
+            client.pem: "{{ (lookup('file', cert_dir.path + '/admin_key.pem') + '\n' + lookup('file', cert_dir.path + '/admin_cert.pem')) | b64encode }}"
+      when: admin_cert_query.resources|length == 0
 
 - name: cleanup
   file:

--- a/mbox-operator/roles/koji-hub/tasks/main.yml
+++ b/mbox-operator/roles/koji-hub/tasks/main.yml
@@ -103,3 +103,28 @@
     - file:
         path: /tmp/deployment.yml
         state: absent
+
+# it creates an user using the same username used in the admin cert CN field
+# and grants admin perms (user_perms table) to it.
+# it ignores any kind of conflict errors in case the user already exists.
+- block:
+    - name: psql admin user setup
+      postgresql_query:
+        db: "{{ psql_secret.data.POSTGRES_DB | b64decode }}"
+        login_host: "{{ psql_secret.data.POSTGRES_HOST | b64decode }}"
+        login_user: "{{ psql_secret.data.POSTGRES_USER | b64decode }}"
+        login_password: "{{ psql_secret.data.POSTGRES_PASSWORD | b64decode }}"
+        query: INSERT INTO users(name, status, usertype) VALUES('{{ koji_hub_admin_username }}', 0, 0) ON CONFLICT DO NOTHING
+    - postgresql_query:
+        db: "{{ psql_secret.data.POSTGRES_DB | b64decode }}"
+        login_host: "{{ psql_secret.data.POSTGRES_HOST | b64decode }}"
+        login_user: "{{ psql_secret.data.POSTGRES_USER | b64decode }}"
+        login_password: "{{ psql_secret.data.POSTGRES_PASSWORD | b64decode }}"
+        query: SELECT * FROM users WHERE name='{{ koji_hub_admin_username }}'
+      register: psql_user_query
+    - postgresql_query:
+        db: "{{ psql_secret.data.POSTGRES_DB | b64decode }}"
+        login_host: "{{ psql_secret.data.POSTGRES_HOST | b64decode }}"
+        login_user: "{{ psql_secret.data.POSTGRES_USER | b64decode }}"
+        login_password: "{{ psql_secret.data.POSTGRES_PASSWORD | b64decode }}"
+        query: INSERT INTO user_perms (user_id, perm_id, creator_id) VALUES ({{ psql_user_query.query_result[0].id }}, 1, 1) ON CONFLICT DO NOTHING


### PR DESCRIPTION
fixes #61 

## Changes

* adds admin user to psql
* grants admin user admin perms
* creates an admin client certificate

## Verifications Steps

* check if a new record was added in both users and user_perms table after koji-hub is deployed
* check if koji-hub admin client cert was properly created