### PR TITLE
Adding test-local back again

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,7 +5,7 @@
 - job:
     name: test-local
     run: ci/test-local.yml
-    nodeset: fedora-30-vm
+    nodeset: fedora-30-vm-medium
 - job:
     name: test-docs
     run: ci/test-docs.yml
@@ -13,11 +13,12 @@
 - job:
     name: test-lint
     run: ci/test-default.yml
-    nodeset: fedora-30-vm
+    nodeset: fedora-30-container
 - project:
     check:
       jobs:
         - test-cluster
+        - test-local
         - test-docs
         - test-lint
 

--- a/ci/test-default.yml
+++ b/ci/test-default.yml
@@ -2,13 +2,9 @@
    tasks:
     - name: Install dependencies
       become: true
-      package:
-        name: ['git', 'moby-engine', 'python3-pip', 'container-selinux', 'selinux-policy-base']
-        state: present
-    - name: Install test deps through pip
-      become: true
-      pip:
-        name: ['molecule', 'kubernetes', 'openshift', 'docker', 'jmespath', 'yamllint']
-      become: true
+      dnf:
+        name: 
+          - yamllint
+        state: latest
     - name: Run molecule test (the default only runs lint)
-      command: chdir={{ansible_user_dir}}/{{zuul.project.src_dir}}/mbox-operator molecule test
+      command: chdir={{ansible_user_dir}}/{{zuul.project.src_dir}}/mbox-operator yamllint roles/

--- a/ci/test-local.yml
+++ b/ci/test-local.yml
@@ -2,14 +2,21 @@
    tasks:
     - name: List project directory on the test system
       command: ls -al {{ansible_user_dir}}/{{zuul.project.src_dir}}
-    - name: Install git, pip and podman
+    - name: Install git, pip and moby
       become: true
       package:
-        name: ['git', 'podman', 'python3-pip']
+        name: ['git', 'moby-engine', 'python3-pip']
         state: present
+    - name: Start docker
+      become: true
+      systemd:
+        state: restarted
+        daemon_reload: yes
+        name: docker
     - name: Install libraries through pip 
       become: true
       pip:
         name: ['molecule', 'kubernetes', 'openshift', 'docker', 'jmespath', 'yamllint']
-    - name: Run molecule 
+    - name: Run molecule
+      become: true
       command: chdir={{ansible_user_dir}}/{{zuul.project.src_dir}}/mbox-operator molecule --debug test -s test-local


### PR DESCRIPTION
Previously we had problem starting up the kind cluster in the time-limit.
Medium vm should help.

Additionally, we shouldn't need the full vm for docs and linting :-)