### PR TITLE
koji-builder add host

### DIFF
--- a/docs/source/user-guide/koji-builder.rst
+++ b/docs/source/user-guide/koji-builder.rst
@@ -44,6 +44,12 @@ Parameters
 +----------------------+------------------------------------+---------+
 | vendor               | MBox                               | string  |
 +----------------------+------------------------------------+---------+
+| host_arch            | x86                                | string  |
++----------------------+------------------------------------+---------+
+| host_name            | koji-hub:8443                      | string  |
++----------------------+------------------------------------+---------+
+| ssl_verify           | true                               | boolean |
++----------------------+------------------------------------+---------+
 
 image
 -----
@@ -132,6 +138,28 @@ vendor
 ------
 
 Koji-builder vendor used in rpm headers.
+
+host_arch
+---------
+
+The koji builder host architecture.
+
+host_name
+---------
+
+The koji host name to be used when creating a koji host in koji-hub.
+
+The name should be a qualified hostname address.
+
+This name should be unique in koji and is also used as the koji-build client
+certificate CN field.
+
+ssl_verify
+----------
+
+A boolean flag used to tell koji-builder to verify ssl certs when connectiong to koji-hub.
+
+It should be set to false if using self-signed certs.
 
 Usage
 =====

--- a/mbox-operator/Makefile
+++ b/mbox-operator/Makefile
@@ -3,8 +3,11 @@ NS = default
 
 .PHONY: prepare/crds
 prepare/crds:
-	@kubectl apply -f deploy/crds/apps.fedoraproject.org_mbkojihubs_crd.yaml
 	@kubectl apply -f deploy/crds/apps.fedoraproject.org_mbkojibuilders_crd.yaml
+	@kubectl apply -f deploy/crds/apps.fedoraproject.org_mbmbsbackends_crd.yaml
+	@kubectl apply -f deploy/crds/apps.fedoraproject.org_mbkojihubs_crd.yaml
+	@kubectl apply -f deploy/crds/apps.fedoraproject.org_mbmbsfrontends_crd.yaml
+	@kubectl apply -f deploy/crds/apps.fedoraproject.org_mbkojiras_crd.yaml
 	@kubectl apply -f deploy/crds/apps.fedoraproject.org_mboxes_crd.yaml
 
 .PHONY: prepare/rbac

--- a/mbox-operator/build/Dockerfile
+++ b/mbox-operator/build/Dockerfile
@@ -1,8 +1,8 @@
 FROM quay.io/operator-framework/ansible-operator:v0.16.0
 
 USER root
-RUN dnf install gcc libpq libpq-devel python3-devel -y
-RUN pip3.6 install psycopg2
+RUN dnf install gcc libpq libpq-devel python3-devel krb5-devel -y
+RUN pip3.6 install psycopg2 koji
 USER ${USER_ID}
 
 COPY requirements.yml ${HOME}/requirements.yml

--- a/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojibuilder_cr.yaml
+++ b/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojibuilder_cr.yaml
@@ -14,4 +14,6 @@ spec:
   koji_hub_url: 'https://koji-hub:8443'
   max_jobs: 5
   vendor: MBox
-
+  host_arch: x86
+  host_name: koji-hub:8443
+  ssl_verify: false

--- a/mbox-operator/deploy/operator.yaml.j2
+++ b/mbox-operator/deploy/operator.yaml.j2
@@ -36,6 +36,7 @@ spec:
               value: explicit
             - name: ANSIBLE_DEBUG_LOGS
               value: "True"
+
       volumes:
         - name: runner
           emptyDir: {}

--- a/mbox-operator/molecule/default/asserts/koji-builder.yml
+++ b/mbox-operator/molecule/default/asserts/koji-builder.yml
@@ -50,14 +50,16 @@
                 - "'ReadWriteOnce' in kojibuilder_pvcs.resources[0].spec.accessModes"
                 - "kojibuilder_pvcs.resources[0].spec.resources.requests.storage == '10Gi'"
 
-#      - block:
-#        - name: 'TEST: kojibuilder.pod deployment'
-#          k8s_info:
-#            api_version: v1
-#            kind: Pod
-#            namespace: "{{ namespace }}"
-#          register: pods
-#        - assert:
-#            that:
-#              - pods.resources|length == 1
-#              - pods.resources[0].metadata.labels['app'] == 'koji-builder'
+      - block:
+          - name: 'TEST: kojibuilder.pod deployment'
+            k8s_info:
+              api_version: v1
+              kind: Pod
+              namespace: "{{ namespace }}"
+              label_selectors:
+                - app = koji-builder
+            register: pods
+          - assert:
+              that:
+                - pods.resources|length == 1
+                - pods.resources[0].metadata.labels['app'] == 'koji-builder'

--- a/mbox-operator/roles/koji-builder/defaults/main.yml
+++ b/mbox-operator/roles/koji-builder/defaults/main.yml
@@ -14,3 +14,9 @@ koji_builder_pvc_size: "{{ mnt_pvc_size|default('10Gi') }}"
 koji_builder_koji_hub_url: "{{ koji_hub_url|default('https://koji-hub:8443') }}"
 koji_builder_maxjobs: "{{ max_jobs|default(5) }}"
 koji_builder_vendor: "{{ vendor|default('MBox') }}"
+
+koji_builder_admin_secret: "{{ admin_secret | default('koji-hub-admin-cert') }}"
+
+koji_builder_host_arch: "{{ host_arch | default('x86') }}"
+koji_builder_host_name: "{{ host_name | default('koji-hub:8443') }}"
+koji_builder_ssl_verify: "{{ ssl_verify | default(true) }}"

--- a/mbox-operator/roles/koji-builder/meta/main.yml
+++ b/mbox-operator/roles/koji-builder/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: koji-lib

--- a/mbox-operator/roles/koji-builder/tasks/cert.yml
+++ b/mbox-operator/roles/koji-builder/tasks/cert.yml
@@ -5,6 +5,13 @@
     suffix: cert
   register: cert_dir
 
+- name: create temporary koji directory
+  tempfile:
+    state: directory
+    prefix: kojibuilder
+    suffix: koji
+  register: koji_dir
+
 - name: Retrieve ca secret
   block:
     - k8s_info:
@@ -24,6 +31,9 @@
     - copy:
         content: "{{ ca.data.key | b64decode }}"
         dest: "{{ cert_dir.path }}/ca_key.pem"
+    - copy:
+        content: "{{ ca.data.cert | b64decode }}"
+        dest: "{{ koji_dir.path }}/ca.pem"
 
 - name: Client certificate creation
   block:
@@ -33,7 +43,7 @@
     - openssl_csr:
         path: "{{ cert_dir.path }}/client_req.pem"
         privatekey_path: "{{ cert_dir.path }}/client_key.pem"
-        common_name: "{{ koji_builder_hub_user }}"
+        common_name: "{{ koji_builder_host_name }}"
     - openssl_certificate:
         path: "{{ cert_dir.path }}/client_cert.pem"
         csr_path: "{{ cert_dir.path }}/client_req.pem"

--- a/mbox-operator/roles/koji-builder/tasks/main.yml
+++ b/mbox-operator/roles/koji-builder/tasks/main.yml
@@ -25,16 +25,44 @@
         pvc_size: "{{ koji_builder_pvc_size }}"
         pvc_namespace: "{{ meta.namespace }}"
 
-# - block:
-#     - name: Apply koji-builder deployment
-#       template:
-#         src: deployment.yml.j2
-#         dest: /tmp/deployment.yml
-#     - k8s:
-#         state: present
-#         src: /tmp/deployment.yml
-#         wait: true
-#         namespace: "{{ meta.namespace }}"
-#     - file:
-#         path: /tmp/deployment.yml
-#         state: absent
+- block:
+    - name: add default koji host
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        namespace: "{{ meta.namespace }}"
+        name: "{{ koji_builder_admin_secret }}"
+      register: k8s_res
+    - fail:
+        msg: "Secret not found: {{ koji_builder_admin_secret }}"
+      when: k8s_res.resources|length == 0
+    - set_fact:
+        koji_admin_secret: "{{ k8s_res.resources[0] | from_yaml }}"
+    - copy:
+        content: "{{ koji_admin_secret.data['client.pem'] | b64decode }}"
+        dest: "{{ koji_dir.path }}/admin.pem"
+    - koji_host:
+        server: "{{ koji_builder_koji_hub_url }}/kojihub"
+        host: "{{ koji_builder_host_name }}"
+        arch: "{{ koji_builder_host_arch }}"
+        ssl_auth:
+          cert: "{{ koji_dir.path }}/admin.pem"
+          serverca: "{{ koji_dir.path }}/ca.pem"
+          verify: "{{ koji_builder_ssl_verify }}"
+    - file:
+        state: absent
+        path: "{{ koji_dir.path }}"
+
+- block:
+    - name: Apply koji-builder deployment
+      template:
+        src: deployment.yml.j2
+        dest: /tmp/deployment.yml
+    - k8s:
+        state: present
+        src: /tmp/deployment.yml
+        wait: true
+        namespace: "{{ meta.namespace }}"
+    - file:
+        path: /tmp/deployment.yml
+        state: absent

--- a/mbox-operator/roles/koji-lib/library/koji_host.py
+++ b/mbox-operator/roles/koji-lib/library/koji_host.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+
+# This file is part of the mbbox project.
+# Copyright (C) 2020  Red Hat, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+DOCUMENTATION = '''
+---
+module: koji_host
+
+short_description: Ansible module that ensures a koji host state in a remote koji-hub instance.
+
+description:
+  - This module ensures that a koji host is added in koji
+  - It requires a running koji-hub instance
+
+options:
+    host:
+        description:
+            - a qualified and unique koji hostname
+        required: true
+    arch:
+        description:
+            - a valid koji host archtecture
+        default: x86
+    server:
+        description:
+            - the full koji-hub server url
+        required: true
+    state:
+        description:
+            - the koji desired state
+        default: present
+        choices: present, absent
+    ssl_auth:
+        description:
+            - a dictonary which contains the require ssl authentication info
+    ssl_auth.cert:
+      description:
+        - the client pem file path to use, this file must contain both key and certificate in PEM format  
+    ssl_auth.serverca:
+      description:
+        - the certificate authority PEM file path used by both koji-hub server and koji-builder client pem file
+    ssl_auth.verify:
+      description:
+        - A boolean flag to tell koji-builder to validate the client pem file, should be set to false if using self-signed certificates.
+      default: true
+
+author:
+    - Red Hat, Inc. and others
+'''
+
+EXAMPLES = '''
+- koji_host:
+  server: https://koji-hub:8443/kojihub
+    host: koji-hub:8443
+    arch: x86
+    ssl_auth:
+      cert: /tmp/admin.pem
+      serverca:/tmp/ca.pem
+      verify: false
+'''
+
+from optparse import Values
+
+from ansible.module_utils.basic import AnsibleModule
+import koji
+from koji_cli.lib import activate_session
+
+
+def build():
+  """
+  Builds an AnsibleModule object instance
+  """
+  spec = dict(
+    host=dict(type='str', required=True),
+    arch=dict(type='str', required=True),
+    server=dict(type='str', required=True),
+    state=dict(type='str', default='present', choices=['present', 'absent']),
+    ssl_auth=dict(type='dict')
+  )
+  return AnsibleModule(
+    argument_spec=spec,
+    supports_check_mode=True
+  )
+
+
+def ssl_config(module):
+  """
+  Creates a ssl config dictionary to be used for ssl auth.
+  """
+  ctx = module.params['ssl_auth']
+  try:
+    return {
+      'cert': ctx['cert'],
+      'serverca': ctx['serverca'],
+      'no_ssl_verify': ctx.get('verify', True),
+      'authtype': 'ssl'
+    }
+  except KeyError as e:
+   module.fail_json(changed=False,
+      skipped=False, 
+      failed=True, 
+      error='Missing ssl_auth "%s" key.' % e.args[0])
+
+
+def main():
+  """
+  Main funtion that runs the module. 
+  """
+  module = build()
+  config = {'server': module.params['server']}
+
+  if 'ssl_auth' in module.params:
+    config.update(**ssl_config(module))
+  else:
+    module.fail_json(changed=False,
+      skipped=False, 
+      failed=True, 
+      error='Missing authentication config')
+
+  options = Values(config)
+  session_opts = koji.grab_session_options(options)
+  session = koji.ClientSession(options.server, session_opts)
+  
+  try:
+    session.ssl_login(options.cert, None, options.serverca)
+  except Exception as e:
+    module.fail_json(changed=False,
+      skipped=False,
+      failed=True,
+      error=str(e))
+  host = session.getHost(module.params['host'])
+  if host:
+    module.exit_json(changed=False,
+      skipped=True,
+      failed=False)
+
+  try:
+    host = session.addHost(module.params['host'], module.params['arch'])
+  except Exception as e:
+     module.fail_json(changed=False,
+      skipped=False,
+      failed=True,
+      error=str(e))
+
+  module.exit_json(changed=True,
+    skipped=False,
+    failed=False, result=host)
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
fixes #61 

## Changes

* Setups a koji-hub host when a koji-builder cr is created from the operator using the admin cert
* uses a different cert for koji-buider with no admin access
* builder CN needs to be the same value used as builder host

## Verification

* Run tests
* Deploy builder + hub and koji-builder should not crash