### PR TITLE
builder checks

### DIFF
--- a/mbox-operator/roles/koji-builder/templates/deployment.yml.j2
+++ b/mbox-operator/roles/koji-builder/templates/deployment.yml.j2
@@ -18,6 +18,13 @@ spec:
       - name: koji-builder
         image: {{ koji_builder_image }}
         resources: {}
+        livenessProbe:
+          exec:
+            command:
+              - pgrep
+              - kojid
+          initialDelaySeconds: 5
+          periodSeconds: 15
         volumeMounts:
         - name: config-volume
           mountPath: /etc/kojid


### PR DESCRIPTION
fixes #71 

## Changes

* Adds a liveness probe check for koji-builder

## Verification

* Run tests or deployment - it should work as usual

I couldn't find anything for "readiness check" as checking if kojid is running is the only thing that can be validated - open to suggestions here.