### PR TITLE
Switching the linting ci job from container back to VM

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -13,7 +13,7 @@
 - job:
     name: test-lint
     run: ci/test-default.yml
-    nodeset: fedora-30-container
+    nodeset: fedora-30-vm
 - project:
     check:
       jobs:


### PR DESCRIPTION
There is a problem with module repos, might be a container issue.