### PR TITLE
Add certificates for Kojira

### DIFF
--- a/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojira_cr.yaml
+++ b/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojira_cr.yaml
@@ -10,3 +10,5 @@ spec:
   src: 'no'
   max_repo_tasks: 15
   repo_tasks_limit: 15
+  cacert_secret: koji-hub-ca-cert
+  client_cert_secret: kojira-client-cert

--- a/mbox-operator/molecule/default/asserts/kojira.yml
+++ b/mbox-operator/molecule/default/asserts/kojira.yml
@@ -18,3 +18,17 @@
               - kojira_configmap.resources|length == 1
               - kojira_configmap.resources[0].metadata.labels['app'] == 'kojira'
               - "'kojira.conf' in kojira_configmap.resources[0].data"
+
+        - block:
+          - name: 'TEST: kojira.secret.client-cert'
+            k8s_info:
+              api_version: v1
+              kind: Secret
+              namespace: "{{ namespace }}"
+              name: kojira-client-cert 
+            register: kojira_client_secrets
+          - assert:
+              that:
+                - kojira_client_secrets.resources|length == 1
+                - kojira_client_secrets.resources[0].metadata.labels['app'] == 'kojira'
+                - "'client.pem' in kojira_client_secrets.resources[0].data"

--- a/mbox-operator/roles/kojira/defaults/main.yml
+++ b/mbox-operator/roles/kojira/defaults/main.yml
@@ -1,7 +1,11 @@
 ---
+# defaults file for kojira
 kojira_configmap: kojira-config
 kojira_hub_username: "{{ hub_username | default('kojira') }}"
 kojira_hub_host: "{{ hub_host | default('koji-hub:8443') }}"
 kojira_src: "{{ src | default('no') }}"
 kojira_max_repo_tasks: "{{ max_repo_tasks | default(15) }}"
 kojira_repo_tasks_limit: "{{ repo_tasks_limit | default(15) }}"
+
+kojira_cacert_secret: "{{ cacert_secret|default('kojira-ca-cert') }}"
+kojira_client_cert_secret: "{{ client_cert_secret|default('kojira-client-cert') }}"

--- a/mbox-operator/roles/kojira/tasks/cert.yml
+++ b/mbox-operator/roles/kojira/tasks/cert.yml
@@ -1,0 +1,78 @@
+- name: create temporary cert directory
+  tempfile:
+    state: directory
+    prefix: kojira
+    suffix: cert
+  register: cert_dir
+
+- name: create temporary koji directory
+  tempfile:
+    state: directory
+    prefix: kojira
+    suffix: koji
+  register: koji_dir
+
+- name: Retrieve ca secret
+  block:
+    - k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ kojira_cacert_secret }}"
+        namespace: "{{ meta.namespace }}"
+      register: k8s_secrets
+    - fail:
+        msg: "Secret {{ kojira_cacert_secret }} not found."
+      when: k8s_secrets.resources|length == 0
+    - set_fact:
+        ca: "{{ k8s_secrets.resources[0] }}"
+    - copy:
+        content: "{{ ca.data.cert | b64decode }}"
+        dest: "{{ cert_dir.path }}/ca_cert.pem"
+    - copy:
+        content: "{{ ca.data.key | b64decode }}"
+        dest: "{{ cert_dir.path }}/ca_key.pem"
+    - copy:
+        content: "{{ ca.data.cert | b64decode }}"
+        dest: "{{ koji_dir.path }}/ca.pem"
+
+- name: Client certificate creation
+  block:
+    - openssl_privatekey:
+        path: "{{ cert_dir.path }}/client_key.pem"
+        size: 4096
+    - openssl_csr:
+        path: "{{ cert_dir.path }}/client_req.pem"
+        privatekey_path: "{{ cert_dir.path }}/client_key.pem"
+        common_name: "{{ kojira_hub_username }}"
+    - openssl_certificate:
+        path: "{{ cert_dir.path }}/client_cert.pem"
+        csr_path: "{{ cert_dir.path }}/client_req.pem"
+        ownca_path: "{{ cert_dir.path }}/ca_cert.pem"
+        ownca_privatekey_path: "{{ cert_dir.path }}/ca_key.pem"
+        provider: ownca
+
+- name: Kubernetes client certificate secret creation
+  block:
+    - k8s_info:
+        api_version: v1
+        kind: Secret
+        name: "{{ kojira_client_cert_secret }}"
+        namespace: "{{ meta.namespace }}"
+      register: clientcert_query
+    - k8s:
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ kojira_client_cert_secret }}"
+            namespace: "{{ meta.namespace }}"
+            labels:
+              app: kojira
+          data:
+            client.pem: "{{ (lookup('file', cert_dir.path + '/client_key.pem') + '\n' + lookup('file', cert_dir.path + '/client_cert.pem')) | b64encode }}"
+      when: clientcert_query.resources|length == 0
+
+- name: cleanup
+  file:
+    path: "{{ cert_dir.path }}"
+    state: absent

--- a/mbox-operator/roles/kojira/tasks/main.yml
+++ b/mbox-operator/roles/kojira/tasks/main.yml
@@ -21,3 +21,5 @@
   file:
     path: "{{ kojira_dir.path }}"
     state: absent
+
+- include_tasks: cert.yml

--- a/mbox-operator/roles/kojira/templates/kojira.configmap.yaml.j2
+++ b/mbox-operator/roles/kojira/templates/kojira.configmap.yaml.j2
@@ -10,7 +10,7 @@ data:
     ; Configuration authentication
     serverca = /etc/cacert/cert
     user={{ kojira_hub_username }}
-    cert=/etc/clientcert/{{ kojira_hub_username }}.pem
+    cert=/etc/clientcert/client.pem
 
     server=https://{{ kojira_hub_host }}/kojihub
     with_src={{ kojira_src }}


### PR DESCRIPTION
This adds the certificates for Kojira. This is done similar way as
in koji-builder.

Closes #35.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>