### PR TITLE
Add configmap for mbs-frontend

### DIFF
--- a/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbmbsfrontend_cr.yaml
+++ b/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbmbsfrontend_cr.yaml
@@ -5,5 +5,18 @@ metadata:
   labels:
     app: mb-mbs-frontend
 spec:
-  # Add fields here
-  size: 3
+  configmap: mbs-frontend-configmap
+  host: 'mbs'
+  https_enabled: true
+  mbs_configmap: mbs-configmap
+  fedora-versions: ['32']
+  hub_host: 'https://koji-hub:8443'
+  messaging_system: 'fedmsg'
+  topic_prefix: 'org.fedoraproject.dev'
+  scm_url: 'git+https://src.fedoraproject.org/modules/'
+  rpms_default_repository: 'git+https://src.fedoraproject.org/rpms/' 
+  rpms_default_cache: 'https://src.fedoraproject.org/repo/pkgs/'
+  modules_default_repository: 'git+https://src.fedoraproject.org/modules/'
+  postgres_secret: postgres
+  pdc_url: 'https://pdc.stg.fedoraproject.org/rest_api/v1'
+  oidc_required_scope: 'https://mbs.fedoraproject.org/oidc/submit-build'

--- a/mbox-operator/molecule/default/asserts/mbs-frontend.yml
+++ b/mbox-operator/molecule/default/asserts/mbs-frontend.yml
@@ -6,5 +6,30 @@
     ansible_python_interpreter: '{{ ansible_playbook_python }}'
   tasks:
       - block:
-        - name: 'TEST: placeholder'
-          meta: noop
+        - name: 'TEST: mbs-frontend.configmap'
+          k8s_info:
+            api_version: v1
+            kind: ConfigMap
+            namespace: "{{ namespace }}"
+            name: mbs-frontend-configmap
+          register: mbs_configmap
+        - assert:
+            that:
+              - mbs_configmap.resources|length == 1
+              - mbs_configmap.resources[0].metadata.labels['app'] == 'mbs-frontend'
+              - "'httpd.conf' in mbs_configmap.resources[0].data"
+
+      - block:
+        - name: 'TEST: mbs-frontend.mbs-configmap'
+          k8s_info:
+            api_version: v1
+            kind: ConfigMap
+            namespace: "{{ namespace }}"
+            name: mbs-configmap
+          register: mbs_configmap
+        - assert:
+            that:
+              - mbs_configmap.resources|length == 1
+              - "'default_module_f32.yml' in mbs_configmap.resources[0].data"
+              - "'koji.conf' in mbs_configmap.resources[0].data"
+              - "'config.py' in mbs_configmap.resources[0].data"

--- a/mbox-operator/roles/mbs-frontend/defaults/main.yml
+++ b/mbox-operator/roles/mbs-frontend/defaults/main.yml
@@ -1,2 +1,20 @@
 ---
 # defaults file for mbs-frontend
+mbs_frontend_configmap: "{{ configmap|default('mbs-frontend-configmap') }}"
+mbs_frontend_host: "{{ host|default('mbs') }}"
+mbs_frontend_https_enabled: "{{ https_enabled|default(true) }}"
+mbs_frontend_http_port: "{{ http_port|default(8080) }}"
+mbs_frontend_https_port: "{{ https_port|default(8443) }}"
+
+mbs_configmap: "{{ mbs_configmap|default('mbs-configmap') }}"
+mbs_fedora_versions: "{{ fedora_versions|default(['32']) }}"
+mbs_hub_host: "{{ hub_host|default('https://koji-hub:8443') }}"
+mbs_messaging_system: "{{ messaging_sytem|default('fedmsg') }}"
+mbs_topic_prefix: "{{ topic_prefix|default('org.fedoraproject.dev') }}"
+mbs_scm_url: "{{ scm_url|default('git+https://src.fedoraproject.org/modules/') }}"
+mbs_rpms_default_repository: "{{ rpms_default_repository|default('git+https://src.fedoraproject.org/rpms/') }}"
+mbs_rpms_default_cache: "{{ rpms_default_cache|default('https://src.fedoraproject.org/repo/pkgs/') }}"
+mbs_modules_default_repository: "{{ modules_default_repository|default('git+https://src.fedoraproject.org/modules/') }}"
+mbs_postgres_secret: "{{ postgres_secret|default('postgres') }}"
+mbs_pdc_url: "{{ pdc_url|default('https://pdc.stg.fedoraproject.org/rest_api/v1') }}"
+mbs_oidc_required_scope: "{{ oidc_required_scope|default('https://mbs.fedoraproject.org/oidc/submit-build') }}"

--- a/mbox-operator/roles/mbs-frontend/tasks/main.yml
+++ b/mbox-operator/roles/mbs-frontend/tasks/main.yml
@@ -1,1 +1,48 @@
 ---
+- block:
+    - name: retrieve postgresql secret
+      k8s_info:
+        api_version: v1
+        kind: Secret
+        namespace: "{{ meta.namespace }}"
+        name: "{{ postgres_secret }}"
+      register: k8s_psql_secrets
+    - fail:
+        msg: "Secret {{ postgres_secret }} not found in namespace {{ meta.namespace }}"
+      when: k8s_psql_secrets.resources|length == 0
+    - set_fact:
+        psql_secret: "{{ k8s_psql_secrets.resources[0] }}"
+
+- name: create temporary mbs-frontend directory
+  tempfile:
+    state: directory
+    prefix: mbs-frontend
+    suffix: deploy
+  register: mbs_frontend_dir
+
+- block:
+    - name: ensure mbs-frontend configmap
+      template:
+        src: mbs-frontend.configmap.yaml.j2
+        dest: "{{ mbs_frontend_dir.path }}/mbs-frontend.configmap.yaml"
+    - k8s:
+        state: present
+        wait: true
+        namespace: "{{ meta.namespace }}"
+        src: "{{ mbs_frontend_dir.path }}/mbs-frontend.configmap.yaml"
+
+- block:
+    - name: ensure mbs configmap
+      template:
+        src: mbs-configmap.yaml.j2
+        dest: "{{ mbs_frontend_dir.path }}/mbs-configmap.yaml"
+      vars:
+        mbs_psql_hostname: "{{ psql_secret.data.POSTGRES_HOST | b64decode }}"
+        mbs_psql_db_name: "{{ psql_secret.data.POSTGRES_DB | b64decode }}"
+        mbs_psql_user: "{{ psql_secret.data.POSTGRES_USER | b64decode }}"
+        mbs_psql_pass: "{{ psql_secret.data.POSTGRES_PASSWORD | b64decode }}"
+    - k8s:
+        state: present
+        wait: true
+        namespace: "{{ meta.namespace }}"
+        src: "{{ mbs_frontend_dir.path }}/mbs-configmap.yaml"

--- a/mbox-operator/roles/mbs-frontend/templates/.keep
+++ b/mbox-operator/roles/mbs-frontend/templates/.keep
@@ -1,1 +1,0 @@
-This is just a placeholder file, otherwise you can't keep empty folder in git 

--- a/mbox-operator/roles/mbs-frontend/templates/mbs-configmap.yaml.j2
+++ b/mbox-operator/roles/mbs-frontend/templates/mbs-configmap.yaml.j2
@@ -1,0 +1,197 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ mbs_configmap }}
+data:
+{% for fedora_version in mbs_fedora_versions %}
+  default_module_f{{ fedora_version }}.yml: |-
+    data:
+      description: Fedora {{ fedora_version }} traditional base
+      license:
+        module: [MIT]
+      name: platform
+      profiles:
+        buildroot:
+          rpms: [bash, bzip2, coreutils, cpio, diffutils, fedora-release, findutils, gawk,
+            grep, gzip, info, make, patch, redhat-rpm-config, rpm-build, sed, shadow-utils,
+            tar, unzip, util-linux, which, xz]
+        srpm-buildroot:
+          rpms: [bash, fedora-release, fedpkg-minimal, gnupg2, redhat-rpm-config, rpm-build,
+            shadow-utils]
+      stream: f{{ fedora_version }}
+      summary: Fedora {{ fedora_version }} traditional base
+      context: 00000000
+      version: 5
+      xmd:
+        mbs:
+          buildrequires: {}
+          commit: f{{ fedora_version }}
+          requires: {}
+          koji_tag: module-f{{ fedora_version }}-build
+          mse: TRUE
+    document: modulemd
+    version: 1
+{% endfor %}
+
+  koji.conf: |-
+    [koji]
+    server = {{ mbs_hub_host }}/kojihub
+    weburl = {{ mbs_hub_host }}/koji
+    topurl = {{ mbs_hub_host }}/kojifiles
+    authtype = ssl
+    ca = /etc/cacert/cert
+    serverca = /etc/cacert/cert
+    cert = /etc/clientcert/client.pem
+
+  mock.cfg: |-
+    # Nonsense, but what do we do...
+
+  yum.conf: |-
+    # Nonsense, but what do we do...
+
+  config.py: |-
+    from os import path
+
+    # FIXME: workaround for this moment till confdir, dbdir (installdir etc.) are
+    # declared properly somewhere/somehow
+    confdir = path.abspath(path.dirname(__file__))
+    # use parent dir as dbdir else fallback to current dir
+    dbdir = path.abspath(path.join(confdir, '..')) if confdir.endswith('conf') \
+            else confdir
+
+    class ProdConfiguration(object):
+        NO_AUTH = True  # This is a test setup, let's try noauth for now
+
+        SECRET_KEY = '84d9e9f9cd40e66fc6c4c2e9987dce48df3ce98542529fd0'
+        SQLALCHEMY_TRACK_MODIFICATIONS = True
+        # Where we should run when running "manage.py runssl" directly.
+        HOST = '0.0.0.0'
+        PORT = 5000
+
+        # Global network-related values, in seconds
+        NET_TIMEOUT = 120
+        NET_RETRY_INTERVAL = 30
+
+        SYSTEM = 'koji'
+        MESSAGING = '{{ mbs_messaging_system }}'  # or amq
+        MESSAGING_TOPIC_PREFIX = ['{{ mbs_topic_prefix }}']
+        KOJI_CONFIG = '/etc/module-build-service/koji.conf'
+        KOJI_PROFILE = 'koji'
+        ARCHES = ['x86_64']
+        KOJI_PROXYUSER = False
+        KOJI_REPOSITORY_URL = '{{ mbs_hub_host }}/pkgs/repos'
+        #PDC_URL = 'http://modularity.fedorainfracloud.org:8080/rest_api/v1'
+        PDC_INSECURE = True
+        PDC_DEVELOP = True
+        SCMURLS = ["{{ mbs_scm_url }}"]
+
+        # How often should we resort to polling, in seconds
+        # Set to zero to disable polling
+        POLLING_INTERVAL = 600
+
+        # Determines how many builds that can be submitted to the builder
+        # and be in the build state at a time. Set this to 0 for no restrictions
+        # New name
+        NUM_CONCURRENT_BUILDS = 5
+        # Old name https://pagure.io/fm-orchestrator/issue/574
+        NUM_CONSECUTIVE_BUILDS = 5
+
+        RPMS_DEFAULT_REPOSITORY = '{{ mbs_rpms_default_repository }}'
+        RPMS_ALLOW_REPOSITORY = False
+        RPMS_DEFAULT_CACHE = '{{ mbs_rpms_default_cache }}'
+        RPMS_ALLOW_CACHE = False
+
+        MODULES_DEFAULT_REPOSITORY = '{{ mbs_modules_default_repository }}'
+        MODULES_ALLOW_REPOSITORY = False
+
+        # Available backends are: console, file, journal.
+        LOG_BACKEND = 'console'
+
+        # Path to log file when LOG_BACKEND is set to "file".
+        LOG_FILE = 'module_build_service.log'
+
+        # Available log levels are: debug, info, warn, error.
+        LOG_LEVEL = 'debug'
+
+        # Settings for Kerberos
+        KRB_KEYTAB = None
+        KRB_PRINCIPAL = None
+        KRB_CCACHE = None
+
+        DEBUG = False  # Don't turn this on.
+
+        # These groups are allowed to submit builds.
+        ALLOWED_GROUPS = [
+            # https://pagure.io/fesco/issue/1763
+            'packager',
+        ]
+
+        # These groups are allowed to cancel the builds of other users.
+        ADMIN_GROUPS = [
+            # Test env, only packager group exists
+            'packager',
+            'factory2',
+            'releng',
+        ]
+
+        REBUILD_STRATEGY = 'only-changed'
+        REBUILD_STRATEGY_ALLOW_OVERRIDE = True
+
+        SQLALCHEMY_DATABASE_URI = 'postgresql://{{ mbs_psql_user }}:{{ mbs_psql_pass }}@{{ mbs_psql_hostname }}/{{ mbs_psql_db_name }}'
+
+        # https://pagure.io/fm-orchestrator/issue/334
+        KOJI_PROXYUSER = False
+
+        # Our per-build logs for the koji-content generator go here.
+        # CG imports are controlled by KOJI_ENABLE_CONTENT_GENERATOR
+        BUILD_LOGS_DIR = '/var/tmp'
+
+        # Yes, use tls.
+        PDC_INSECURE = False
+        # No, don't try to obtain a token (we just read.  we don't write.)
+        PDC_DEVELOP = True
+
+        KOJI_REPOSITORY_URL = 'https://kojipkgs.stg.fedoraproject.org/repos'
+        PDC_URL = '{{ mbs_pdc_url }}'
+
+        RESOLVER = "db"
+
+        # Made possible by https://pagure.io/releng/issue/6799
+        KOJI_ENABLE_CONTENT_GENERATOR = True
+
+        # See https://pagure.io/releng/issue/7012
+        BASE_MODULE_NAMES = set(['platform', 'bootstrap'])
+        KOJI_CG_BUILD_TAG_TEMPLATE = "{}-modular-updates-candidate"
+        KOJI_CG_DEFAULT_BUILD_TAG = "modular-updates-candidate"
+
+        # This is a whitelist of prefixes of koji tags we're allowed to manipulate
+        KOJI_TAG_PREFIXES = [
+            # This is our standard prefix.  All module tags should start with this.
+            'module',
+        ]
+
+        # If this is too long, we could change it to 'fm_' some day.
+        DEFAULT_DIST_TAG_PREFIX = 'module_'
+
+        # Delete module-* targets one hour after build
+        KOJI_TARGET_DELETE_TIME = 3600
+
+        # These aren't really secret.
+        OIDC_CLIENT_SECRETS = path.join(confdir, 'client_secrets.json')
+        OIDC_REQUIRED_SCOPE = '{{ mbs_oidc_required_scope }}'
+
+        # Don't let people submit yaml directly.  it has to come from dist-git
+        YAML_SUBMIT_ALLOWED = False
+
+        # Set the priority to 4 to have higher priority than F27 mass rebuild.
+        KOJI_BUILD_PRIORITY = 4
+
+        # Check branch EOL before building.  Block EOL modules from building.
+        # https://pagure.io/fm-orchestrator/issue/960
+        # Because of https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/KGXBMTUR72FHQEG7IBHDPPX276QHSD2I/#MFT5SAWPKMCNLKAWEJFCFIVX5GJ7RBSP
+        # we decided to hold on to this and ask the maintainers to create a
+        # releng ticket to retire their modules.
+        CHECK_FOR_EOL = False
+
+        # Koji Content Generator "-devel" modules aren't used in Fedora, so we can just disable them
+        KOJI_CG_DEVEL_MODULE = False

--- a/mbox-operator/roles/mbs-frontend/templates/mbs-frontend.configmap.yaml.j2
+++ b/mbox-operator/roles/mbs-frontend/templates/mbs-frontend.configmap.yaml.j2
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ mbs_frontend_configmap }}
+  labels:
+    app: mbs-frontend
+data:
+  httpd.conf: |-
+    ServerName "{{ mbs_frontend_host }}"
+    ServerRoot "/httpdir"
+    PidFile "/httpdir/httpd.pid"
+    LoadModule authn_file_module modules/mod_authn_file.so
+    LoadModule authn_anon_module modules/mod_authn_anon.so
+    LoadModule authz_user_module modules/mod_authz_user.so
+    LoadModule authz_host_module modules/mod_authz_host.so
+    LoadModule include_module modules/mod_include.so
+    LoadModule log_config_module modules/mod_log_config.so
+    LoadModule env_module modules/mod_env.so
+    LoadModule ext_filter_module modules/mod_ext_filter.so
+    LoadModule expires_module modules/mod_expires.so
+    LoadModule headers_module modules/mod_headers.so
+    LoadModule mime_module modules/mod_mime.so
+    LoadModule status_module modules/mod_status.so
+    LoadModule dir_module modules/mod_dir.so
+    LoadModule alias_module modules/mod_alias.so
+    LoadModule rewrite_module modules/mod_rewrite.so
+    LoadModule version_module modules/mod_version.so
+    LoadModule wsgi_module modules/mod_wsgi_python3.so
+    LoadModule authn_core_module modules/mod_authn_core.so
+    LoadModule authz_core_module modules/mod_authz_core.so
+    LoadModule unixd_module modules/mod_unixd.so
+    LoadModule mpm_event_module modules/mod_mpm_event.so
+    LoadModule ssl_module modules/mod_ssl.so
+    StartServers  20
+    ServerLimit   100
+    MaxRequestsPerChild 2000
+    MaxRequestWorkers 100
+    LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+    CustomLog /httpdir/accesslog combined
+    ErrorLog /httpdir/errorlog
+    LogLevel debug
+    TypesConfig /etc/mime.types
+    AddDefaultCharset UTF-8
+    CoreDumpDirectory /tmp
+{% if mbs_frontend_https_enabled %}
+    Listen 0.0.0.0:{{ mbs_frontend_https_port }} https
+
+    <VirtualHost *:{{ mbs_frontend_https_port }}>
+        ServerName "{{ mbs_frontend_host }}"
+        TypesConfig /etc/mime.types
+        AddDefaultCharset UTF-8
+        SSLEngine on
+        SSLProtocol TLSv1.2
+    </VirtualHost>
+{% else %}
+    Listen 0.0.0.0:{{ mbs_frontend_http_port }} http
+
+    <VirtualHost *:{{ mbs_frontend_http_port }}>
+        ServerName "{{ mbs_frontend_host }}"
+        TypesConfig /etc/mime.types
+        AddDefaultCharset UTF-8
+    </VirtualHost>
+{% endif %}
+
+    WSGIDaemonProcess mbs_frontend display-name=mbs_frontend processes=2 threads=2 maximum-requests=1000 home=/tmp/httpdir
+    WSGIProcessGroup mbs_frontend
+    WSGIApplicationGroup %{GLOBAL}
+    WSGISocketPrefix run/wsgi
+    WSGIRestrictStdout Off
+    WSGIRestrictSignal Off
+    WSGIPythonOptimize 1
+
+    WSGIScriptAlias / /mbs.wsgi
+    <Location />
+      Require all granted
+    </Location>
+
+    RewriteEngine on
+    RewriteRule ^(|/+)$ /module-build-service/1/module-builds/ [L,R=302]
+
+    SSLCertificateFile /etc/servicecert/tls.crt
+    SSLCertificateKeyFile /etc/servicecert/tls.key
+    SSLCertificateChainFile /etc/cacert/cert


### PR DESCRIPTION
Add two configmaps for mbs-frontend, one contains configuration specific
for the mbs-frontend, second contains shared configuration for
mbs-frontend and mbs-backend.

Closes #44

Signed-off-by: Michal Konečný <mkonecny@redhat.com>