### PR TITLE
mbox secret and pvc

### DIFF
--- a/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml
+++ b/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml
@@ -3,4 +3,7 @@ kind: Mbox
 metadata:
   name: example-mbox
 spec:
-  size: 1
+  koji_pvc_name: mbox-koji-mnt
+  koji_pvc_size: 10Gi
+  root_ca_secret_name: mbox-koji-root-ca
+  koji_hub_host: koji-hub:8443

--- a/mbox-operator/molecule/default/asserts/mbox.yml
+++ b/mbox-operator/molecule/default/asserts/mbox.yml
@@ -1,0 +1,22 @@
+---
+- name: Verify
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+  tasks:
+      - block:
+          - name: mbox.secret.root_ca
+            k8s_info:
+              api_version: v1
+              kind: Secret
+              namespace: "{{ namespace }}"
+              name: mbox-koji-root-ca
+            register: k8s_secrets
+          - assert:
+              that:
+                - k8s_secrets.resources|length == 1
+                - k8s_secrets.resources[0].metadata.labels['app'] == 'mbox'
+                - "'ca_req.pem' in k8s_secrets.resources[0].data"
+                - "'ca_cert.pem' in k8s_secrets.resources[0].data"
+                - "'ca_key.pem' in k8s_secrets.resources[0].data"

--- a/mbox-operator/molecule/default/converge/converge_mbox.yml
+++ b/mbox-operator/molecule/default/converge/converge_mbox.yml
@@ -1,0 +1,15 @@
+---
+- name: Converge
+  hosts: localhost
+  connection: local
+  vars:
+    ansible_python_interpreter: '{{ ansible_playbook_python }}'
+    deploy_dir: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') }}/deploy"
+    pull_policy: Never
+    REPLACE_IMAGE:  apps.fedoraproject.org/mbox-operator:testing
+    custom_resource: "{{ lookup('file', '/'.join([deploy_dir, 'crds/apps.fedoraproject.org_v1alpha1_mbox_cr.yaml'])) | from_yaml }}"
+
+  tasks:
+    - import_tasks: '{{ playbook_dir }}/tasks/mbox.yml'
+
+- import_playbook: '{{ playbook_dir }}/../../default/asserts/mbox.yml'

--- a/mbox-operator/molecule/default/converge/tasks/mbox.yml
+++ b/mbox-operator/molecule/default/converge/tasks/mbox.yml
@@ -1,0 +1,87 @@
+---
+- block:
+    - name: Delete the Operator Deployment
+      k8s:
+        state: absent
+        namespace: '{{ namespace }}'
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml.j2'])) }}"
+      register: delete_deployment
+
+    - name: Wait 30s for Operator Deployment to terminate
+      k8s_info:
+        api_version: '{{ definition.apiVersion }}'
+        kind: '{{ definition.kind }}'
+        namespace: '{{ namespace }}'
+        name: '{{ definition.metadata.name }}'
+      vars:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml.j2'])) | from_yaml }}"
+      register: deployment
+      until: not deployment.resources
+      delay: 3
+      retries: 10
+      when: delete_deployment.changed
+
+    - name: Create the Operator Deployment
+      k8s:
+        namespace: '{{ namespace }}'
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml.j2'])) }}"
+
+    - name: Create required custom resources
+      k8s:
+        state: present
+        namespace: '{{ namespace }}'
+        definition: '{{ custom_resource }}'
+
+    - name: Wait 5m for reconciliation to run
+      k8s_info:
+        api_version: '{{ custom_resource.apiVersion }}'
+        kind: '{{ custom_resource.kind }}'
+        namespace: '{{ namespace }}'
+        name: '{{ custom_resource.metadata.name }}'
+      register: cr
+      until:
+        - "'Successful' in (cr | json_query('resources[].status.conditions[].reason'))"
+      delay: 10
+      retries: 30
+  rescue:
+    - name: debug cr
+      ignore_errors: true
+      failed_when: false
+      debug:
+        var: debug_cr
+      vars:
+        debug_cr: '{{ lookup("k8s",
+          kind=custom_resource.kind,
+          api_version=custom_resource.apiVersion,
+          namespace=namespace,
+          resource_name=custom_resource.metadata.name
+        )}}'
+
+    - name: get sdk operator logs
+      ignore_errors: true
+      failed_when: false
+      command: kubectl logs `kubectl get pod --selector name=mbox-operator -o jsonpath='{.items[0].metadata.name}'` operator -n {{ namespace }}
+      environment:
+        KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+      vars:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml.j2'])) | from_yaml }}"
+      register: log
+
+    - debug: var=log.stdout_lines
+
+    - name: get ansible operator logs
+      ignore_errors: true
+      failed_when: false
+      command: kubectl logs `kubectl get pod --selector name=mbox-operator -o jsonpath='{.items[0].metadata.name}'` ansible -n {{ namespace }}
+      environment:
+        KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
+      vars:
+        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml.j2'])) | from_yaml }}"
+      register: log
+
+    - debug: var=log.stdout_lines
+
+    - debug: var=log.stdout_lines
+      
+    - fail:
+        msg: "Failed on action: converge"

--- a/mbox-operator/molecule/test-cluster/converge.yml
+++ b/mbox-operator/molecule/test-cluster/converge.yml
@@ -16,6 +16,7 @@
       register: build_cmd
       changed_when: not prev_hash.stdout or (prev_hash.stdout and prev_hash.stdout not in ''.join(build_cmd.stdout_lines[-2:]))
 
+- import_playbook: '{{ playbook_dir }}/../default/converge/converge_mbox.yml'
 - import_playbook: '{{ playbook_dir }}/../default/converge/converge_koji-hub.yml'
 - import_playbook: '{{ playbook_dir }}/../default/converge/converge_koji-builder.yml'
 - import_playbook: '{{ playbook_dir }}/../default/converge/converge_kojira.yml'

--- a/mbox-operator/molecule/test-local/converge.yml
+++ b/mbox-operator/molecule/test-local/converge.yml
@@ -18,6 +18,7 @@
       changed_when: not prev_hash.stdout or (prev_hash.stdout and prev_hash.stdout not in ''.join(build_cmd.stdout_lines[-2:]))
 
 
+- import_playbook: '{{ playbook_dir }}/../default/converge/converge_mbox.yml'
 - import_playbook: '{{ playbook_dir }}/../default/converge/converge_koji-hub.yml'
 - import_playbook: '{{ playbook_dir }}/../default/converge/converge_koji-builder.yml'
 - import_playbook: '{{ playbook_dir }}/../default/converge/converge_kojira.yml'

--- a/mbox-operator/roles/mbox/defaults/main.yml
+++ b/mbox-operator/roles/mbox/defaults/main.yml
@@ -1,2 +1,6 @@
 ---
 # defaults file for mbox
+mbox_koji_pvc_name: "{{ koji_pvc_name | default('mbox-koji-mnt') }}"
+mbox_koji_pvc_size: "{{ koji_pvc_size | default('10Gi') }}"
+mbox_root_ca_secret_name: "{{ root_ca_secret_name | default('mbox-root-ca') }}"
+mbox_koji_hub_host: "{{ koji_hub_host | default('koji-hub:8443') }}"

--- a/mbox-operator/roles/mbox/tasks/cert.yml
+++ b/mbox-operator/roles/mbox/tasks/cert.yml
@@ -1,0 +1,79 @@
+- block:
+    - name: create temporary cert directory
+      set_fact:
+        mbox_cert_dir: "{{ mbox_dir.path }}/certs"
+    - file:
+        path: "{{ mbox_cert_dir }}"
+        state: directory
+
+- k8s_info:
+    api_version: v1
+    kind: Secret
+    namespace: "{{ meta.namespace }}"
+    name: "{{ mbox_root_ca_secret_name }}"
+  register: k8s_secrets
+
+- block:
+    - name: validate existing cert
+      set_fact:
+        k8s_mbox_secret: "{{ k8s_secrets.resources[0] | from_yaml }}"
+    - fail:
+        msg: "ca_req.pem key not found in {{ mbox_root_ca_secret_name }} secret"
+      when: "not 'ca_req.pem' in k8s_mbox_secret.data"
+    - fail:
+        msg: "ca_cert.pem key not found in {{ mbox_root_ca_secret_name }} secret"
+      when: "not 'ca_cert.pem' in k8s_mbox_secret.data"
+    - fail:
+        msg: "ca_key.pem key not found in {{ mbox_root_ca_secret_name }} secret"
+      when: "not 'ca_key.pem' in k8s_mbox_secret.data"
+  when: k8s_secrets.resources|length == 1
+
+- block:
+    - name: create self signed cert
+      openssl_privatekey:
+        path: "{{ mbox_cert_dir }}/ca_key.pem"
+        size: 4096
+    - openssl_csr:
+        path: "{{ mbox_cert_dir }}/ca_req.pem"
+        privatekey_path: "{{ mbox_cert_dir }}/ca_key.pem"
+        common_name: "{{ mbox_koji_hub_host }}"
+        create_subject_key_identifier: true
+        key_usage:
+          - cRLSign
+          - dataEncipherment
+          - digitalSignature
+          - keyCertSign
+          - keyEncipherment
+          - nonRepudiation
+        basic_constraints:
+          - 'CA:TRUE'
+    - openssl_certificate:
+        path: "{{ mbox_cert_dir }}/ca_cert.pem"
+        privatekey_path: "{{ mbox_cert_dir }}/ca_key.pem"
+        csr_path: "{{ mbox_cert_dir }}/ca_req.pem"
+        provider: selfsigned
+    - set_fact:
+        ca_req: "{{ lookup('file', mbox_cert_dir + '/ca_req.pem') }}"
+        ca_cert: "{{ lookup('file', mbox_cert_dir + '/ca_cert.pem') }}"
+        ca_key: "{{ lookup('file', mbox_cert_dir + '/ca_key.pem') }}"
+    - k8s:
+        wait: true
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ mbox_root_ca_secret_name }}"
+            namespace: "{{ meta.namespace }}"
+            labels:
+              app: mbox
+          data:
+            ca_req.pem: "{{ lookup('file', mbox_cert_dir + '/ca_req.pem') | b64encode }}"
+            ca_cert.pem: "{{ lookup('file', mbox_cert_dir + '/ca_cert.pem') | b64encode }}"
+            ca_key.pem: "{{ lookup('file', mbox_cert_dir + '/ca_key.pem') | b64encode }}"
+  when: k8s_secrets.resources|length == 0
+
+- name: delete temporary cert directory
+  file:
+    path: "{{ mbox_cert_dir }}"
+    state: absent

--- a/mbox-operator/roles/mbox/tasks/main.yml
+++ b/mbox-operator/roles/mbox/tasks/main.yml
@@ -1,31 +1,39 @@
 ---
-# tasks file for mbox
-- name: start memcached
-  k8s:
-    definition:
-      kind: Deployment
-      apiVersion: apps/v1
-      metadata:
-        name: '{{ meta.name }}-memcached'
-        namespace: '{{ meta.namespace }}'
-      spec:
-        replicas: "{{size}}"
-        selector:
-          matchLabels:
-            app: memcached
-        template:
+- name: create temporary mbox directory
+  tempfile:
+    state: directory
+    prefix: mbox
+    suffix: deploy
+  register: mbox_dir
+
+- include_tasks: cert.yml
+
+- block:
+    - name: mbox.pvc
+      k8s_info:
+        api_version: v1
+        kind: PersistentVolumeClaim
+        namespace: "{{ meta.namespace }}"
+        name: "{{ mbox_koji_pvc_name }}"
+      register: k8s_mbox_pvc_query
+    - k8s:
+        state: present
+        wait: true
+        definition:
+          apiVersion: v1
+          kind: PersistentVolumeClaim
           metadata:
+            namespace: "{{ meta.namespace }}"
+            name: "{{ mbox_koji_pvc_name }}"
             labels:
-              app: memcached
+              app: mbox
           spec:
-            containers:
-              - name: memcached
-                command:
-                  - memcached
-                  - -m=64
-                  - -o
-                  - modern
-                  - -v
-                image: "docker.io/memcached:1.4.36-alpine"
-                ports:
-                  - containerPort: 11211
+            accessModes:
+              - ReadWriteMany
+            resources:
+              requests:
+                storage: "{{ mbox_koji_pvc_size }}"
+            selector:
+              matchLabels:
+                app: mbox
+      when: k8s_mbox_pvc_query.resources|length == 0


### PR DESCRIPTION
<!--
Related Pull Request issue (if any)
-->
Fixes #33 

<!--
Please include what has changed
-->
## Proposed Changes

* Mbox cr creates a ca secret and pvc object to be used by other components;
* Both ca secret and pvc are not created if already present using the same name in the same namespace.

<!--
Steps required to validate your changes
-->
## Verification Steps

* Run tests

<!--
Extra information, if any, that might be relevant to the PR
-->
## Additional Notes

The usage of those shared resources on other components will be implemented in other PRs.
