### PR TITLE
using koji plugin url from pagure

### DIFF
--- a/images/koji-hub/Dockerfile
+++ b/images/koji-hub/Dockerfile
@@ -4,7 +4,7 @@ RUN dnf install --setopt tsflags= -y \
 koji koji-hub koji-web koji-hub-plugins \
 curl httpd mod_ssl postgresql fedora-messaging python3-mod_wsgi
 
-RUN curl https://infrastructure.fedoraproject.org/cgit/ansible.git/plain/roles/koji_hub/templates/fedmsg-koji-plugin.py -o /usr/lib/koji-hub-plugins/fedmsg-koji-plugin.py
+RUN curl https://pagure.io/fedora-infra/ansible/raw/master/f/roles/koji_hub/templates/fedmsg-koji-plugin.py -o /usr/lib/koji-hub-plugins/fedmsg-koji-plugin.py
 RUN rm -f /etc/kojiweb/web.conf && \
 ln -s /etc/koji-hub/kojiweb.conf /etc/kojiweb/web.conf
 RUN chown -R 1001:root /etc/koji-hub && \


### PR DESCRIPTION
<!--
Please include what has changed
-->
## Proposed Changes

* Changes the url of `fedmsg-koji-plugin.py` since the ansible repository was moved to pagure;

<!--
Steps required to validate your changes
-->
## Verification Steps

* Check if the new url is correct

<!--
Extra information, if any, that might be relevant to the PR
-->
## Additional Notes

Just a change of URLs since the old url was returning a 404 error.
