### PR TITLE
kojiweb cert support

### DIFF
--- a/docs/source/user-guide/koji-hub.rst
+++ b/docs/source/user-guide/koji-hub.rst
@@ -24,47 +24,51 @@ Sample deployment files are provided for development/example purposes:
 Parameters
 ==========
 
-+----------------------+--------------------------------+---------+
-| Name                 | Default Value                  | Type    |
-+======================+================================+=========+
-| image                | quay.io/fedora/koji-hub:latest | string  |
-+----------------------+--------------------------------+---------+
-| replicas             | 1                              | int     |
-+----------------------+--------------------------------+---------+
-| persistent           | true                           | boolean |
-+----------------------+--------------------------------+---------+
-| host                 | koji-hub                       | string  |
-+----------------------+--------------------------------+---------+
-| configmap            | koji-hub                       | string  |
-+----------------------+--------------------------------+---------+
-| ca_cert_secret       | koji-hub-ca-cert               | string  |
-+----------------------+--------------------------------+---------+
-| service_cert_secret  | koji-hub-service-cert          | string  |
-+----------------------+--------------------------------+---------+
-| postgres_secret      | postgres                       | string  |
-+----------------------+--------------------------------+---------+
-| http_enabled         | true                           | boolean |
-+----------------------+--------------------------------+---------+
-| https_enabled        | true                           | boolean |
-+----------------------+--------------------------------+---------+
-| topic_prefix         | mbox_dev                       | string  |
-+----------------------+--------------------------------+---------+
-| fedora_messaging_url |                                | string  |
-+----------------------+--------------------------------+---------+
-| messaging_cert_cm    | koji-hub-msg                   | string  |
-+----------------------+--------------------------------+---------+
-| ingress_backend      | nginx                          | string  |
-+----------------------+--------------------------------+---------+
-| mbox                 | ""                             | string  |
-+----------------------+--------------------------------+---------+
-| httpd_pvc_name       | koji-hub-httpd-pvc             | string  |
-+----------------------+--------------------------------+---------+
-| httpd_pvc_size       | 1Gi                            | string  |
-+----------------------+--------------------------------+---------+
-| mnt_pvc_name         | koji-hub-mnt-pvc               | string  |
-+----------------------+--------------------------------+---------+
-| mnt_pvc_size         | 10Gi                           | string  |
-+----------------------+--------------------------------+---------+
++------------------------+--------------------------------+---------+
+| Name                   | Default Value                  | Type    |
++========================+================================+=========+
+| image                  | quay.io/fedora/koji-hub:latest | string  |
++------------------------+--------------------------------+---------+
+| replicas               | 1                              | int     |
++------------------------+--------------------------------+---------+
+| persistent             | true                           | boolean |
++------------------------+--------------------------------+---------+
+| host                   | koji-hub                       | string  |
++------------------------+--------------------------------+---------+
+| configmap              | koji-hub                       | string  |
++------------------------+--------------------------------+---------+
+| ca_cert_secret         | koji-hub-ca-cert               | string  |
++------------------------+--------------------------------+---------+
+| service_cert_secret    | koji-hub-service-cert          | string  |
++------------------------+--------------------------------+---------+
+| postgres_secret        | postgres                       | string  |
++------------------------+--------------------------------+---------+
+| http_enabled           | true                           | boolean |
++------------------------+--------------------------------+---------+
+| https_enabled          | true                           | boolean |
++------------------------+--------------------------------+---------+
+| topic_prefix           | mbox_dev                       | string  |
++------------------------+--------------------------------+---------+
+| fedora_messaging_url   |                                | string  |
++------------------------+--------------------------------+---------+
+| messaging_cert_cm      | koji-hub-msg                   | string  |
++------------------------+--------------------------------+---------+
+| ingress_backend        | nginx                          | string  |
++------------------------+--------------------------------+---------+
+| mbox                   | ""                             | string  |
++------------------------+--------------------------------+---------+
+| httpd_pvc_name         | koji-hub-httpd-pvc             | string  |
++------------------------+--------------------------------+---------+
+| httpd_pvc_size         | 1Gi                            | string  |
++------------------------+--------------------------------+---------+
+| mnt_pvc_name           | koji-hub-mnt-pvc               | string  |
++------------------------+--------------------------------+---------+
+| mnt_pvc_size           | 10Gi                           | string  |
++------------------------+--------------------------------+---------+
+| web_client_cert_secret | koji-hub-web-client-cert       | string  |
++------------------------+--------------------------------+---------+
+| web_client_username    | kojihub                        | string  |
++------------------------+--------------------------------+---------+
 
 
 image
@@ -268,6 +272,43 @@ Koji-builder will use the following vars if this property is missing to create/u
 * mnt_pvc_name (shared koji mnt volume)
 * ca_cert_secret (root ca secret)
 * postgres_secret (PSQL secret)
+
+web_client_cert_secret
+----------------------
+
+The koji-web secret name to use or create for koji-hub authentication.
+
+It will skip its creation (self signed) if one is already present.
+
+It needs to be created and signed using the root CA certificate and private key.
+
+It should have one key "client.pem" to store both private key and public certificate.
+
+The certificate's CN field will be used as username during authentication. 
+
+Secret format:
+
+.. code-block:: yaml
+
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: koji-hub-wen-client-cert-secret
+    namespace: default
+    labels:
+      app: koji-hub
+  data:
+    client.pem: -|
+      fillme
+
+
+web_client_username
+-------------------
+
+Koji web client username to be used when authenticating to koji-hub.
+
+This property will be ignored if not using a self-signed certificate generated by the operator.
+
 
 Usage
 =====

--- a/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojihub_cr.yaml
+++ b/mbox-operator/deploy/crds/apps.fedoraproject.org_v1alpha1_mbkojihub_cr.yaml
@@ -23,4 +23,7 @@ spec:
   httpd_pvc_size: 1Gi
   mnt_pvc_name: koji-hub-mnt-pvc
   mnt_pvc_size: 10Gi
+  web_client_cert_secret: koji-hub-web-client-cert
+  web_client_username: kojiweb
+
   # mbox: example-mbox #uncomment to retrieve pvc and cert config from a mbox cr

--- a/mbox-operator/molecule/default/asserts/koji-hub.yml
+++ b/mbox-operator/molecule/default/asserts/koji-hub.yml
@@ -53,6 +53,20 @@
                 - "'tls.key' in kojihub_secrets.resources[0].data"
 
       - block:
+          - name: 'TEST: kojihub.secret.koji-hub-web-client-cert'
+            k8s_info:
+              api_version: v1
+              kind: Secret
+              namespace: "{{ namespace }}"
+              name: koji-hub-web-client-cert
+            register: kojihub_secrets
+          - assert:
+              that:
+                - kojihub_secrets.resources|length == 1                
+                - kojihub_secrets.resources[0].metadata.labels['app'] == 'koji-hub'
+                - "'client.pem' in kojihub_secrets.resources[0].data"
+
+      - block:
           - name: 'TEST: kojihub.pvcs'
             k8s_info:
               api_version: v1

--- a/mbox-operator/roles/koji-hub/defaults/main.yml
+++ b/mbox-operator/roles/koji-hub/defaults/main.yml
@@ -28,3 +28,6 @@ koji_hub_ingress_backend: "{{ ingress_backend | default('nginx') }}"
 koji_hub_admin_username: "{{ admin_username | default('kojiadmin') }}"
 
 koji_mbox: "{{ mbox | default('') }}"
+
+koji_hub_web_client_cert: "{{ web_client_cert | default('koji-hub-web-client-cert') }}"
+koji_hub_web_client_username: "{{ web_client_username | default('kojiweb') }}"

--- a/mbox-operator/roles/koji-hub/tasks/cert.yml
+++ b/mbox-operator/roles/koji-hub/tasks/cert.yml
@@ -131,6 +131,41 @@
             client.pem: "{{ (lookup('file', cert_dir.path + '/admin_key.pem') + '\n' + lookup('file', cert_dir.path + '/admin_cert.pem')) | b64encode }}"
   when: k8s_admin_cert_query.resources|length == 0
 
+# koji-web client cert
+- name: check if kojiweb client cert exists
+  k8s_info:
+    api_version: v1
+    kind: Secret
+    name: "{{ koji_hub_web_client_cert }}"
+    namespace: "{{ meta.namespace }}"
+  register: k8s_web_cert_query
+- block:
+    - openssl_privatekey:
+        path: "{{ cert_dir.path }}/client_web_key.pem"
+        size: 4096
+    - openssl_csr:
+        path: "{{ cert_dir.path }}/client_web_req.pem"
+        privatekey_path: "{{ cert_dir.path }}/client_web_key.pem"
+        common_name: "{{ koji_hub_web_client_username }}"
+    - openssl_certificate:
+        path: "{{ cert_dir.path }}/client_web_cert.pem"
+        csr_path: "{{ cert_dir.path }}/client_web_req.pem"
+        ownca_path: "{{ cert_dir.path }}/ca_cert.pem"
+        ownca_privatekey_path: "{{ cert_dir.path }}/ca_key.pem"
+        provider: ownca
+    - k8s:
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: "{{ koji_hub_web_client_cert }}"
+            namespace: "{{ meta.namespace }}"
+            labels:
+              app: koji-hub
+          data:
+            client.pem: "{{ (lookup('file', cert_dir.path + '/client_web_key.pem') + '\n' + lookup('file', cert_dir.path + '/client_web_cert.pem')) | b64encode }}"
+  when: k8s_web_cert_query.resources|length == 0
+
 - name: cleanup
   file:
     path: "{{ cert_dir.path }}"

--- a/mbox-operator/roles/koji-hub/templates/configmap.yml.j2
+++ b/mbox-operator/roles/koji-hub/templates/configmap.yml.j2
@@ -136,7 +136,7 @@ data:
     LibPath = /usr/share/koji-web/lib
     LoginDisabled = True
     KojiHubCA = /etc/cacert/cert
-    InsecureNoSSLVerify = True
+    WebCert = /etc/webcert/client.pem
 
     Tasks = runroot
   fedora-messaging.toml: |-

--- a/mbox-operator/roles/koji-hub/templates/deployment.yml.j2
+++ b/mbox-operator/roles/koji-hub/templates/deployment.yml.j2
@@ -39,6 +39,9 @@ spec:
             - name: cacert-volume
               mountPath: /etc/cacert
               readOnly: true
+            - name: webcert-volume
+              mountPath: /etc/webcert
+              readOnly: true
             - name: service-cert-volume
               mountPath: /etc/servicecert
               readOnly: true
@@ -55,6 +58,9 @@ spec:
         - name: service-cert-volume
           secret:
             secretName: "{{ koji_hub_service_cert_secret }}"
+        - name: webcert-volume
+          secret:
+            secretName: "{{ koji_hub_web_client_cert }}"
         - name: config-volume
           configMap:
             name: "{{ koji_hub_configmap }}"


### PR DESCRIPTION
<!--
Please include what has changed
-->
## Proposed Changes

* adds a koji-web client cert for koji-web ssl auth in koji-hub

<!--
Steps required to validate your changes
-->
## Verification Steps

* run tests

<!--
Extra information, if any, that might be relevant to the PR
-->
## Additional Notes

There is an upstream koji PR that needs to be merged for koji-web work with certs: https://pagure.io/koji/pull-request/2450

Please change the image of koji-hub to `quay.io/lrossett/koji-hub:patch for the web UI validation if needed while that PR is not merged and available as a RPM update. 
