### PR TITLE
cert vars

### DIFF
--- a/docs/source/user-guide/koji-hub.rst
+++ b/docs/source/user-guide/koji-hub.rst
@@ -91,7 +91,9 @@ Note: I will not create any external volumes if set to false.
 host
 ----
 
-The koji-hub hostname to be used on several config files such as httpd.
+The koji-hub hostname to be used on several config files and certificates such as httpd.
+
+This property should be set to the public base url of koji on production environments.
 
 configmap
 ---------

--- a/mbox-operator/roles/koji-hub/tasks/cert.yml
+++ b/mbox-operator/roles/koji-hub/tasks/cert.yml
@@ -74,6 +74,11 @@
         path: "{{ cert_dir.path }}/server_req.pem"
         privatekey_path: "{{ cert_dir.path }}/server_key.pem"
         common_name: "{{ koji_hub_host }}"
+        subject_alt_name:
+          - "DNS:{{ koji_hub_host }}"
+          - "DNS:{{ koji_hub_svc_name }}"
+          - "DNS:{{ koji_hub_svc_name }}.{{ meta.namespace }}.svc"
+          - "DNS:{{ koji_hub_svc_name }}.{{ meta.namespace }}.svc.cluster"
     - openssl_certificate:
         path: "{{ cert_dir.path }}/server_cert.pem"
         csr_path: "{{ cert_dir.path }}/server_req.pem"

--- a/mbox-operator/roles/koji-hub/templates/configmap.yml.j2
+++ b/mbox-operator/roles/koji-hub/templates/configmap.yml.j2
@@ -130,7 +130,7 @@ data:
   kojiweb.conf: |-
     [web]
     SiteName = MBOX Koji
-    KojiHubURL = https://{{ koji_hub_host }}:8443/kojihub
+    KojiHubURL = https://{{ koji_hub_svc_name }}:{{ koji_hub_https_port }}/kojihub
     KojiFilesURL = https://{{ koji_hub_host }}/pkgs
     Secret = MboxKojiWeb
     LibPath = /usr/share/koji-web/lib


### PR DESCRIPTION
<!--
Please include what has changed
-->
## Proposed Changes

* uses `koji_hub_host` value for HTTPD CN field
* sets a list of `subject_alt_name`values based on kubernetes/openshift internal service urls
* uses koji-hub internal url in web.conf for internal koji-hub calls

<!--
Steps required to validate your changes
-->
## Verification Steps

* run tests

<!--
Extra information, if any, that might be relevant to the PR
-->
## Additional Notes
