### PR TITLE
using full qualified service name for api calls

### DIFF
--- a/docs/source/user-guide/koji-builder.rst
+++ b/docs/source/user-guide/koji-builder.rst
@@ -34,7 +34,9 @@ Parameters
 +----------------------+------------------------------------+----------+
 | koji_hub_user        | 'koji-builder.mbox.dev'            | string   |
 +----------------------+------------------------------------+----------+
-| koji_hub_url         | 'https://koji-hub:8443'            | string   |
+| koji_hub_host        | 'koji-hub'                         | string   |
++----------------------+------------------------------------+----------+
+| koji_hub_port        | 8443                               | string   |
 +----------------------+------------------------------------+----------+
 | max_jobs             | 5                                  | int      |
 +----------------------+------------------------------------+----------+
@@ -113,10 +115,15 @@ koji_hub_user
 
 User to use when authenticating with koji-hub.
 
-koji_hub_url
-------------
+koji_hub_host
+-------------
 
-URL of the koji-hub koji-builder will connect to.
+Hostname of the koji-hub server instance that koji-builder will connect to.
+
+koji_hub_port
+-------------
+
+Port of the koji-hub server instance that koji-builder will connect to.
 
 max_jobs
 --------
@@ -196,7 +203,8 @@ Create a file containing the following content (modify as needed):
     cacert_secret: koji-hub-ca-cert
     client_cert_secret: koji-builder-client-cert
     koji_hub_user: 'koji-builder.mbox.dev'
-    koji_hub_url: 'https://koji-hub:8443'
+    koji_hub_host: 'koji-hub'
+    koji_hub_port: 8443
     max_jobs: 5
     vendor: MBox
     host_archs:

--- a/mbox-operator/config/samples/apps_v1alpha1_mbkojibuilder.yaml
+++ b/mbox-operator/config/samples/apps_v1alpha1_mbkojibuilder.yaml
@@ -9,7 +9,8 @@ spec:
   cacert_secret: koji-hub-ca-cert
   client_cert_secret: koji-builder-client-cert
   koji_hub_user: 'koji-builder.mbox.dev'
-  koji_hub_url: 'https://koji-hub:8443'
+  koji_hub_host: 'koji-hub'
+  koji_hub_port: 8443
   max_jobs: 5
   vendor: MBox
   host_archs:

--- a/mbox-operator/roles/koji-builder/defaults/main.yml
+++ b/mbox-operator/roles/koji-builder/defaults/main.yml
@@ -8,7 +8,8 @@ koji_builder_cacert_secret: "{{ cacert_secret|default('koji-builder-ca-cert') }}
 koji_builder_client_cert_secret: "{{ client_cert_secret|default('koji-builder-client-cert') }}"
 koji_builder_hub_user: "{{ koji_hub_user|default('koji-builder.mbox.dev') }}"
 
-koji_builder_koji_hub_url: "{{ koji_hub_url|default('https://koji-hub:8443') }}"
+koji_builder_koji_hub_host: "{{ koji_hub_host|default('koji-hub') }}"
+koji_builder_koji_hub_port: "{{ koji_hub_port|default(8443) }}"
 koji_builder_maxjobs: "{{ max_jobs|default(5) }}"
 koji_builder_vendor: "{{ vendor|default('MBox') }}"
 

--- a/mbox-operator/roles/koji-builder/tasks/main.yml
+++ b/mbox-operator/roles/koji-builder/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- set_fact:
+    koji_builder_koji_hub_url: "https://{{ koji_builder_koji_hub_host }}.{{ meta.namespace }}.svc:{{ koji_builder_koji_hub_port }}"
 - block:
     - name: retrieve mbox resource
       k8s_info:

--- a/mbox-operator/roles/koji-hub/tasks/main.yml
+++ b/mbox-operator/roles/koji-hub/tasks/main.yml
@@ -179,22 +179,24 @@
 # it ignores any kind of conflict errors in case the user already exists.
 - block:
     - name: psql admin user setup
-      postgresql_query:
+      set_fact:
+        psql_host: "{{ psql_secret.data.POSTGRES_HOST | b64decode }}.{{ psql_secret.metadata.namespace }}.svc"
+    - postgresql_query:
         db: "{{ psql_secret.data.POSTGRES_DB | b64decode }}"
-        login_host: "{{ psql_secret.data.POSTGRES_HOST | b64decode }}"
+        login_host: "{{ psql_host }}"
         login_user: "{{ psql_secret.data.POSTGRES_USER | b64decode }}"
         login_password: "{{ psql_secret.data.POSTGRES_PASSWORD | b64decode }}"
         query: INSERT INTO users(name, status, usertype) VALUES('{{ koji_hub_admin_username }}', 0, 0) ON CONFLICT DO NOTHING
     - postgresql_query:
         db: "{{ psql_secret.data.POSTGRES_DB | b64decode }}"
-        login_host: "{{ psql_secret.data.POSTGRES_HOST | b64decode }}"
+        login_host: "{{ psql_host }}"
         login_user: "{{ psql_secret.data.POSTGRES_USER | b64decode }}"
         login_password: "{{ psql_secret.data.POSTGRES_PASSWORD | b64decode }}"
         query: SELECT * FROM users WHERE name='{{ koji_hub_admin_username }}'
       register: psql_user_query
     - postgresql_query:
         db: "{{ psql_secret.data.POSTGRES_DB | b64decode }}"
-        login_host: "{{ psql_secret.data.POSTGRES_HOST | b64decode }}"
+        login_host: "{{ psql_host }}"
         login_user: "{{ psql_secret.data.POSTGRES_USER | b64decode }}"
         login_password: "{{ psql_secret.data.POSTGRES_PASSWORD | b64decode }}"
         query: INSERT INTO user_perms (user_id, perm_id, creator_id) VALUES ({{ psql_user_query.query_result[0].id }}, 1, 1) ON CONFLICT DO NOTHING


### PR DESCRIPTION
## Proposed Changes

* Uses fully qualified name for services when doing API calls from the operator pod;
* Uses fully qualified name for services when running PSQL queries from the operator pod;
* Split `koji_hub_url` into two new properties for the koji-builder CR (`koji_host` and `koji_port`);
* Documentation changes due to CRD changes. 

<!--
Steps required to validate your changes
-->
## Verification Steps

* Run tests or a VM deployment

<!--
Extra information, if any, that might be relevant to the PR
-->
## Additional Notes
