### PR TITLE
Add kerberos deployment

### DIFF
--- a/components/kerberos/0-service.yaml
+++ b/components/kerberos/0-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kerberos
+  labels:
+    app: kerberos
+    service: kerberos
+spec:
+  ports:
+    - name: "kdc" 
+      port: 88
+      targetPort: 88
+      protocol: TCP
+    - name: "kadmin"
+      port: 749
+      targetPort: 749
+      protocol: TCP
+  selector:
+    app: kerberos

--- a/components/kerberos/1-configmap.yaml
+++ b/components/kerberos/1-configmap.yaml
@@ -1,0 +1,107 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kerberos-configmap
+data:
+  krb5.conf: |-
+    [logging]                                  
+    default = FILE:/var/log/krb5libs.log      
+    kdc = FILE:/var/log/krb5kdc.log           
+    admin_server = FILE:/var/log/kadmind.log  
+
+    [libdefaults]                              
+    ticket_lifetime = 24000                   
+    default_realm = DEFAULT.SVC.CLUSTER.LOCAL            
+
+    [realms]                                   
+    DEFAULT.SVC.CLUSTER.LOCAL = {                         
+    kdc = kerberos.default.svc.cluster.local:88           
+    admin_server = kerberos.default.svc.cluster.local:749 
+    default_domain = default.svc.cluster.local           
+    }                                         
+
+    [domain_realm]                             
+    .default.svc.cluster.local = DEFAULT.SVC.CLUSTER.LOCAL            
+    default.svc.cluster.local = DEFAULT.SVC.CLUSTER.LOCAL            
+
+    [kdc]                                      
+    profile = /etc/kerberos/kdc.conf  
+
+    [pam]
+    debug = false
+    ticket_lifetime = 36000
+    renew_lifetime = 36000
+    forwardable = true
+    krb4_convert = false
+
+  kdc.conf: |-
+    [kdcdefaults]                                                                   
+    kdc_ports = 88                                                                 
+    acl_file = /etc/kerberos/kadm5.acl                                     
+    dict_file = /usr/dict/words                                                    
+    admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab                              
+
+    [realms]                                                                        
+    DEFAULT.SVC.CLUSTER.LOCAL = {                                                              
+      database_name = /var/kerberos/krb5kdc/principal                               
+      admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab                             
+      kadmind_port = 749                                                            
+      acl_file = /etc/kerberos/kadm5.acl                                    
+      dict_file = /usr/dict/words                                                   
+    }
+
+  kadm5.acl: |-
+    */admin@DEFAULT.SVC.CLUSTER.LOCAL *
+
+  start.sh: |-
+    #!/bin/sh
+
+    # Create kerberos database
+    expect -c "
+    spawn kdb5_util create -s
+    expect \"Enter KDC database master key:\"
+    send \"admin\n\"
+    expect \"Re-enter KDC database master key to verify:\"
+    send \"admin\n\"
+    expect eof
+    exit
+    "
+
+    # Start services
+    krb5kdc
+    kadmin
+
+    # Create principals and add them to keytab
+    expect -c "
+    spawn kadmin.local
+    # Create principal host/krb-server.default.svc.cluster.local
+    expect \"kadmin.local:\"
+    send \"addprinc host/krb-server.default.svc.cluster.local\n\"
+    expect \"Enter password for principal 'host/krb-server.default.svc.cluster.local@DEFAULT.SVC.CLUSTER.LOCAL':\"
+    send \"admin\n\"
+    expect \"Re-enter password for principal 'host/krb-server.default.svc.cluster.local@DEFAULT.SVC.CLUSTER.LOCAL':\"
+    send \"admin\n\"
+    expect \"Principal 'host/krb-server.test.mbobx.com@DEFAULT.SVC.CLUSTER.LOCAL' created.\"
+
+    # Create principal root
+    expect \"kadmin.local:\"
+    send \"addprinc root\n\"
+    expect \"Enter password for principal 'root@DEFAULT.SVC.CLUSTER.LOCAL':\"
+    send \"admin\n\"
+    expect \"Re-enter password for principal 'root@DEFAULT.SVC.CLUSTER.LOCAL':\"
+    send \"admin\n\"
+    expect \"Principal 'root@DEFAULT.SVC.CLUSTER.LOCAL' created.\"
+
+    # Add the host to keytab
+    expect \"kadmin.local:\"
+    send \"ktadd -k /etc/krb5.keytab host/krb-server.default.svc.cluster.local\n\"
+    expect \"Entry for principal host/krb-server.default.svc.cluster.local with kvno 2, encryption type DES cbc mode with CRC-32 added to keytab WRFILE:/etc/krb5.keytab.\"
+    expect \"Entry for principal host/krb-server.default.svc.cluster.local with kvno 2, encryption type Triple DES cbc mode raw added to keytab WRFILE:/etc/krb5.keytab.\"
+    expect \"kadmin.local:\"
+    send \"exit\n\"
+    expect eof
+    exit
+    "
+
+    # Keep the eye on the log
+    tail -f /var/log/krb5kdc.log

--- a/components/kerberos/2-deployment.yaml
+++ b/components/kerberos/2-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kerberos
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kerberos
+  template:
+    metadata:
+      labels:
+        app: kerberos
+    spec:
+      containers:
+        - name: kerberos
+          image: quay.io/zlopez/kerberos:latest
+          env:
+            - name: KRB5_CONFIG
+              value: "/etc/kerberos/krb5.conf"
+          command: ["bash"]
+          args: ["/etc/kerberos/start.sh"]
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 88
+            - containerPort: 749
+          volumeMounts:
+          - name: config-volume
+            mountPath: /etc/kerberos
+            readOnly: true
+      volumes:
+      - name: config-volume
+        configMap:
+          name: kerberos-configmap
+      - name: kdc-config-volume
+        configMap:
+          name: kerberos-kdc-configmap

--- a/components/kerberos/README.md
+++ b/components/kerberos/README.md
@@ -1,0 +1,5 @@
+# Kerberos deployment
+
+A kerberos kubernetes deployment for development purposes.
+
+It can be deployed by running `kubectl apply -f .`

--- a/images/kerberos/Dockerfile
+++ b/images/kerberos/Dockerfile
@@ -1,0 +1,6 @@
+FROM fedora:33
+
+RUN dnf install -y krb5-libs krb5-server krb5-workstation expect
+
+EXPOSE 88
+EXPOSE 749


### PR DESCRIPTION
This commit adds everything that is need to build the working kerberos
container and deploy it in kubernetes cluster.

Closes #140

## Proposed Changes

* Add kerberos Dockerfile
* Add kerberos configmap
* Add kerberos deployment
* Add kerberos service

## Verification Steps

* `cd components/kerberos`
* `kubectl apply -f .`
* `kubectl exec -it <kerberos pod> -- kinit` (default password is `admin`)
* No error thrown

## Additional Notes
In minikube you need to do the following to let verification steps to work:
* `minikube ssh`
* `sudo ip link set docker0 promisc on`