### PR TITLE
Add kerberos to molecule tests

### DIFF
--- a/components/kerberos/1-configmap.yaml
+++ b/components/kerberos/1-configmap.yaml
@@ -11,18 +11,18 @@ data:
 
     [libdefaults]                              
     ticket_lifetime = 24000                   
-    default_realm = DEFAULT.SVC.CLUSTER.LOCAL            
+    default_realm = KERBEROS            
 
     [realms]                                   
-    DEFAULT.SVC.CLUSTER.LOCAL = {                         
-    kdc = kerberos.default.svc.cluster.local:88           
-    admin_server = kerberos.default.svc.cluster.local:749 
-    default_domain = default.svc.cluster.local           
+    KERBEROS = {                         
+    kdc = kerberos:88           
+    admin_server = kerberos:749 
+    default_domain = kerberos           
     }                                         
 
     [domain_realm]                             
-    .default.svc.cluster.local = DEFAULT.SVC.CLUSTER.LOCAL            
-    default.svc.cluster.local = DEFAULT.SVC.CLUSTER.LOCAL            
+    .kerberos = KERBEROS            
+    kerberos = KERBEROS            
 
     [kdc]                                      
     profile = /etc/kerberos/kdc.conf  
@@ -42,7 +42,7 @@ data:
     admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab                              
 
     [realms]                                                                        
-    DEFAULT.SVC.CLUSTER.LOCAL = {                                                              
+    KERBEROS = {                                                              
       database_name = /var/kerberos/krb5kdc/principal                               
       admin_keytab = /var/kerberos/krb5kdc/kadm5.keytab                             
       kadmind_port = 749                                                            
@@ -51,7 +51,7 @@ data:
     }
 
   kadm5.acl: |-
-    */admin@DEFAULT.SVC.CLUSTER.LOCAL *
+    */admin@KERBEROS *
 
   start.sh: |-
     #!/bin/sh
@@ -68,35 +68,44 @@ data:
     "
 
     # Start services
-    krb5kdc
-    kadmin
+    /usr/sbin/krb5kdc
+    /usr/sbin/kadmind
 
     # Create principals and add them to keytab
     expect -c "
     spawn kadmin.local
-    # Create principal host/krb-server.default.svc.cluster.local
+    # Create principal host
     expect \"kadmin.local:\"
-    send \"addprinc host/krb-server.default.svc.cluster.local\n\"
-    expect \"Enter password for principal 'host/krb-server.default.svc.cluster.local@DEFAULT.SVC.CLUSTER.LOCAL':\"
+    send \"addprinc host/kerberos\n\"
+    expect \"Enter password for principal 'host/kerberos@KERBEROS':\"
     send \"admin\n\"
-    expect \"Re-enter password for principal 'host/krb-server.default.svc.cluster.local@DEFAULT.SVC.CLUSTER.LOCAL':\"
+    expect \"Re-enter password for principal 'host/kerberos@KERBEROS':\"
     send \"admin\n\"
-    expect \"Principal 'host/krb-server.test.mbobx.com@DEFAULT.SVC.CLUSTER.LOCAL' created.\"
+    expect \"Principal 'host/kerberos@KERBEROS' created.\"
 
     # Create principal root
     expect \"kadmin.local:\"
     send \"addprinc root\n\"
-    expect \"Enter password for principal 'root@DEFAULT.SVC.CLUSTER.LOCAL':\"
+    expect \"Enter password for principal 'root@KERBEROS':\"
     send \"admin\n\"
-    expect \"Re-enter password for principal 'root@DEFAULT.SVC.CLUSTER.LOCAL':\"
+    expect \"Re-enter password for principal 'root@KERBEROS':\"
     send \"admin\n\"
-    expect \"Principal 'root@DEFAULT.SVC.CLUSTER.LOCAL' created.\"
+    expect \"Principal 'root@KERBEROS' created.\"
+
+    # Create principal root/admin
+    expect \"kadmin.local:\"
+    send \"addprinc root/admin\n\"
+    expect \"Enter password for principal 'root/admin@KERBEROS':\"
+    send \"admin\n\"
+    expect \"Re-enter password for principal 'root/admin@KERBEROS':\"
+    send \"admin\n\"
+    expect \"Principal 'root/admin@KERBEROS' created.\"
 
     # Add the host to keytab
     expect \"kadmin.local:\"
-    send \"ktadd -k /etc/krb5.keytab host/krb-server.default.svc.cluster.local\n\"
-    expect \"Entry for principal host/krb-server.default.svc.cluster.local with kvno 2, encryption type DES cbc mode with CRC-32 added to keytab WRFILE:/etc/krb5.keytab.\"
-    expect \"Entry for principal host/krb-server.default.svc.cluster.local with kvno 2, encryption type Triple DES cbc mode raw added to keytab WRFILE:/etc/krb5.keytab.\"
+    send \"ktadd -k /etc/krb5.keytab host/kerberos\n\"
+    expect \"Entry for principal host/kerberos with kvno 2, encryption type DES cbc mode with CRC-32 added to keytab WRFILE:/etc/krb5.keytab.\"
+    expect \"Entry for principal host/kerberos with kvno 2, encryption type Triple DES cbc mode raw added to keytab WRFILE:/etc/krb5.keytab.\"
     expect \"kadmin.local:\"
     send \"exit\n\"
     expect eof

--- a/components/kerberos/2-deployment.yaml
+++ b/components/kerberos/2-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: kerberos
-          image: quay.io/zlopez/kerberos:latest
+          image: quay.io/fedora/kerberos:latest
           env:
             - name: KRB5_CONFIG
               value: "/etc/kerberos/krb5.conf"

--- a/mbox-operator/molecule/default/converge.yml
+++ b/mbox-operator/molecule/default/converge.yml
@@ -27,6 +27,17 @@
         - 2-deployment.yaml
         - 3-service.yaml
 
+    - name: Deploy kerberos
+      k8s:
+        src: "{{ components_dir }}/kerberos/{{ item }}"
+        namespace: "{{ namespace }}"
+        state: present
+        wait: true
+      with_items:
+        - 0-service.yaml
+        - 1-configmap.yaml
+        - 2-deployment.yaml
+        
     - name: Create RabbitMQ ConfigMap
       k8s:
         src: "{{ components_dir }}/rabbitmq/1-app.secret.yaml"


### PR DESCRIPTION
Prepare test environment for mbbox components to be tested with
kerberos.

Fixes #147

## Proposed Changes

* Fix kadmin service in kerberos container
* Use quay.oi/fedora/kerberos repository for image
* Deploy kerberos in molecule tests
* Make kerberos domain more general (don't use namespace specific)

## Verification Steps

* `molecule converge -s test-local`
* `docker exec -it kind-test-local bash`
* `kubectl config set-context --current --namespace=osdk-test`
* `kubectl exec -it <kerberos_pod> -- kinit`

## Additional Notes
For verification steps to work, you need to run `sudo ip link set docker0 promisc on` in molecule test container
