### PR TITLE
Update zuul config to use a recent fedora nodeset

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -6,15 +6,15 @@
 - job:
     name: test-local
     run: ci/test-local.yml
-    nodeset: fedora-30-vm-medium
+    nodeset: fedora-36-vm-medium
 - job:
     name: test-docs
     run: ci/test-docs.yml
-    nodeset: fedora-30-vm
+    nodeset: fedora-36-vm
 - job:
     name: test-lint
     run: ci/test-default.yml
-    nodeset: fedora-30-vm
+    nodeset: fedora-36-vm
 - project:
     check:
       jobs:


### PR DESCRIPTION
This CI configuration prevent us to merge:
https://pagure.io/fedora-zuul-jobs/pull-request/160